### PR TITLE
fix(skills): drone routing, name validator, pytest, template

### DIFF
--- a/src/skills/apps/modules/creator.py
+++ b/src/skills/apps/modules/creator.py
@@ -104,4 +104,4 @@ def _is_valid_name(name):
     """
     if not name or not name[0].isalpha():
         return False
-    return all(c.isalnum() or c == "-" for c in name) and name == name.lower()
+    return all(c.isalnum() or c in "-_" for c in name) and name == name.lower()

--- a/src/skills/apps/skills.py
+++ b/src/skills/apps/skills.py
@@ -14,6 +14,18 @@
 #   - Formats and prints output
 # =============================================
 
+import sys
+from pathlib import Path
+# Ensure src/ is on sys.path so 'skills' package is resolvable.
+# Also remove the script's own directory (apps/) from sys.path to prevent
+# this file (skills.py) from shadowing the 'skills' package.
+_script_dir = str(Path(__file__).resolve().parent)
+if _script_dir in sys.path:
+    sys.path.remove(_script_dir)
+_src_dir = str(Path(__file__).resolve().parents[2])  # skills/apps/skills.py -> src/
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
 """Skills system entry point.
 
 Provides handle_command(command, args) for drone routing.

--- a/src/skills/pytest.ini
+++ b/src/skills/pytest.ini
@@ -8,11 +8,12 @@ python_functions = test_*
 python_classes = Test*
 
 # Command-line options (always applied)
+# Verbose output, short traceback, strict markers, show summary of all outcomes
 addopts =
-    -v                          # Verbose output
-    --tb=short                  # Short traceback format
-    --strict-markers            # Raise error on unknown markers
-    -ra                         # Show summary of all test outcomes
+    -v
+    --tb=short
+    --strict-markers
+    -ra
 
 # Test markers (for categorizing tests)
 markers =

--- a/src/skills/templates/full/handler.py
+++ b/src/skills/templates/full/handler.py
@@ -1,0 +1,24 @@
+"""
+{{SKILL_NAME}} — Full 3-layer skill handler.
+
+Scaffolded by: drone @skills create {{SKILL_NAME}} --full
+"""
+
+
+def run(action: str, args: list, config: dict) -> dict:
+    """
+    Execute the skill.
+
+    Args:
+        action: The action to perform
+        args: Command arguments
+        config: Skill configuration from SKILL.md
+
+    Returns:
+        dict with keys: success (bool), output (str), error (str|None)
+    """
+    return {
+        "success": True,
+        "output": f"{{SKILL_NAME}} executed action: {action}",
+        "error": None,
+    }


### PR DESCRIPTION
## Summary
- **P0**: Fix sys.path in skills.py so `drone @skills list/info/run/validate` work (script name shadowed package)
- **P1**: Allow underscores in skill names (`system_status`, `drone_commands`)
- **P1**: Fix pytest.ini broken inline comments (74 tests pass)
- **P2**: Add missing handler.py to full template

## Test plan
- [x] `drone @skills list` — shows 3 catalog skills
- [x] `drone @skills info system_status` — displays skill info
- [x] `drone @skills validate system_status` — validation passes
- [x] 74 unit/integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)