### PR TITLE
fix(setup): seed .env into ~/.secrets/aipass/ on bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # AIPass API Keys
-# Copy this file to .env and fill in your keys:
-#   cp .env.example .env
+# Location: ~/.secrets/aipass/.env (setup.sh copies this automatically)
+# Do NOT put real keys in the repo — this is just a template.
 
 # OpenAI
 OPENAI_API_KEY=

--- a/setup.sh
+++ b/setup.sh
@@ -79,6 +79,12 @@ else
     echo "Secrets directory already exists — skipping"
 fi
 
+# --- Seed .env template into secrets ---
+if [ ! -f "$SECRETS_DIR/.env" ] && [ -f ".env.example" ]; then
+    cp .env.example "$SECRETS_DIR/.env"
+    echo "  Copied .env.example → ~/.secrets/aipass/.env (add your API keys there)"
+fi
+
 # --- Generate branch registry ---
 if [ ! -f "AIPASS_REGISTRY.json" ]; then
     echo "Generating AIPASS_REGISTRY.json ..."


### PR DESCRIPTION
## Summary
- `setup.sh` now copies `.env.example` → `~/.secrets/aipass/.env` on first run
- Updated `.env.example` header to point users to the secrets location
- Keys never touch the repo — template only

## Test plan
- [x] Tested end-to-end in Docker container (fresh bootstrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)