### PR TITLE
feat(prax): fix dashboard refresh data pipeline — 4 bugs

### DIFF
--- a/src/aipass/prax/apps/handlers/dashboard/refresh.py
+++ b/src/aipass/prax/apps/handlers/dashboard/refresh.py
@@ -78,8 +78,8 @@ def _extract_flow_section(centrals: Dict, branch_name: str) -> Dict:
 
     active_plans = plans_data.get("active_plans", [])
 
-    # Count plans for this branch
-    branch_plans = [p for p in active_plans if p.get("branch") == branch_name]
+    # Count plans for this branch (case-insensitive — centrals use lowercase, refresh uses uppercase)
+    branch_plans = [p for p in active_plans if p.get("branch", "").upper() == branch_name]
 
     # Get recently_closed from top-level (already limited to 5 by push_central)
     recently_closed_raw = plans_data.get("recently_closed", [])
@@ -93,7 +93,7 @@ def _extract_flow_section(centrals: Dict, branch_name: str) -> Dict:
         "managed_by": "flow",
         "active_plans": len(branch_plans),
         "recently_closed": recently_closed,
-        "last_updated": plans_data.get("last_updated", datetime.now().isoformat())
+        "last_updated": plans_data.get("generated_at", plans_data.get("last_updated", datetime.now().isoformat()))
     }
 
 
@@ -109,7 +109,8 @@ def _extract_ai_mail_section(centrals: Dict, branch_name: str) -> Dict:
     return {
         "managed_by": "ai_mail",
         "unread": stats.get("unread", 0),
-        "total": stats.get("total", 0)
+        "total": stats.get("total", 0),
+        "last_updated": mail_data.get("last_updated", datetime.now().isoformat())
     }
 
 

--- a/src/aipass/prax/apps/prax.py
+++ b/src/aipass/prax/apps/prax.py
@@ -166,7 +166,7 @@ Examples:
     parser.add_argument('--version', '-V', action='version', version='PRAX v2.0.0')
     parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
 
-    parsed_args = parser.parse_args()
+    parsed_args, remaining = parser.parse_known_args()
 
     # If no command provided, show introspection display
     if not parsed_args.command:
@@ -180,8 +180,12 @@ Examples:
         error("No command modules discovered")
         return 1
 
+    # Merge positional args with any flags argparse didn't consume
+    # so subcommand handlers like dashboard can receive --all, --branch, etc.
+    all_args = parsed_args.args + remaining
+
     # Route command to appropriate handler
-    if route_command(parsed_args.command, parsed_args.args, handlers):
+    if route_command(parsed_args.command, all_args, handlers):
         return 0
     else:
         error(f"Unknown command: {parsed_args.command}")


### PR DESCRIPTION
## Summary
- Fix `prax.py` argparse eating `--all`/`--branch` flags before dashboard handler receives them (`parse_args` → `parse_known_args` + forward remaining)
- Fix case-sensitive branch matching in flow extraction — centrals use lowercase (`"branch": "flow"`), refresh compares uppercase (`FLOW`). FLOW was showing 0 active plans instead of 12.
- Add missing `last_updated` timestamp to `ai_mail` section extraction
- Fix flow `last_updated` to read `generated_at` from `PLANS.central.json` (top-level `last_updated` doesn't exist)

## Test plan
- [x] `drone @prax dashboard refresh --all` updates all 15 branches (was failing before argparse fix)
- [x] FLOW dashboard shows 12 active plans (was 0 due to case mismatch)
- [x] PRAX dashboard shows live email counts from AI_MAIL.central.json
- [x] `last_updated` present on both ai_mail and flow sections
- [x] Seedgo audit 95%

🤖 Generated with [Claude Code](https://claude.com/claude-code)