### PR TITLE
chore(system): git workflow — return to main after PR

### DIFF
--- a/.aipass/aipass_global_prompt.md
+++ b/.aipass/aipass_global_prompt.md
@@ -116,6 +116,11 @@ Co-Authored-By: @{branch} <{branch}@aipass>
 
 **Stage from git, not from memory.** Use `git diff --stat` or `git status` to see what's actually changed, then stage those files. Never manually list files to commit from memory — you'll try to add gitignored files or miss real changes. Trust `.gitignore` and let git tell you what changed.
 
+**Return to main after PR.** Git branches are repo-wide — when you create a feature branch, every citizen in the repo is on that branch, not just you. After your PR is created (or merged), switch back to main so you don't strand other citizens on your stale branch:
+```
+git checkout main && git pull    # always do this after PR creation
+```
+
 **Never merge.** Only devpulse or Patrick merge PRs. If your PR gets feedback, fix the issues, commit, and push to the same git branch — the PR updates automatically.
 
 ## Context Guardrail


### PR DESCRIPTION
## Summary
- Add "Return to main after PR" instruction to global prompt
- Explains that git branches are repo-wide and citizens must switch back after PR creation
- Already tested: memory complied immediately on first attempt

## Test plan
- [x] Memory created PR #55 and switched back to main automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)