### PR TITLE
fix(security): enable auth on code-server container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ USER 1000
 ENV PATH="/opt/venv/bin:$PATH"
 
 EXPOSE 8080
-ENTRYPOINT ["/usr/bin/entrypoint.sh", "--bind-addr", "0.0.0.0:8080", "--auth", "none", "/home/coder/workspace"]
+ENTRYPOINT ["/usr/bin/entrypoint.sh", "--bind-addr", "0.0.0.0:8080", "--auth", "password", "/home/coder/workspace"]


### PR DESCRIPTION
## Summary
- Changed `--auth none` to `--auth password` in Dockerfile
- Unauthenticated code-server was exposed to all network interfaces
- Auto-generates random password on first container run

## Test plan
- [x] Built and tested locally in Docker
- [x] Confirmed auth prompt appears on `http://localhost:8081`
- [x] Confirmed password auto-generated in container config
- [x] Confirmed port mapping still works with `0.0.0.0` bind

🤖 Generated with [Claude Code](https://claude.com/claude-code)