### PR TITLE
feat(backup): S62 4-phase rebuild — atomic writes, Google Drive sync, 75 new tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](pyproject.toml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-# AIPass
+# AIPass (UNDER CONSTRUCTION)
 
 A multi-agent operating system where AI agents live as citizens in a shared filesystem. Persistent memory, inter-agent messaging, standards enforcement, and CLI routing — no cloud required.
 

--- a/src/aipass/backup/README.md
+++ b/src/aipass/backup/README.md
@@ -13,9 +13,8 @@
 Builder citizen — full 3-layer architecture with identity and memory.
 
 Provides automated file protection through snapshot backups, versioned backups,
-and Google Drive synchronization. The entry point routes commands to four
-specialized modules: `backup_core`, `google_drive_sync`, `integrations`, and
-`reauth_drive`.
+and Google Drive synchronization. The entry point routes commands to two
+specialized modules: `backup_core` and `google_drive_sync`.
 
 ---
 
@@ -29,16 +28,12 @@ backup/
 │   ├── backup.py                # Entry point (CLI) — drone @backup
 │   ├── modules/
 │   │   ├── backup_core.py       # Core backup operations (snapshot, versioned)
-│   │   ├── google_drive_sync.py # Google Drive sync orchestration
-│   │   ├── integrations.py      # Cross-module integration commands
-│   │   └── reauth_drive.py      # Google Drive re-authentication
+│   │   └── google_drive_sync.py # Google Drive sync orchestration
 │   ├── handlers/
 │   │   ├── config/
 │   │   │   └── config_handler.py        # Configuration management
 │   │   ├── diff/
-│   │   │   ├── diff_generator.py        # Diff generation between backups
-│   │   │   ├── version_manager.py       # Version tracking
-│   │   │   └── vscode_integration.py    # VS Code diff viewer integration
+│   │   │   └── diff_generator.py        # Diff generation between backups
 │   │   ├── json/
 │   │   │   ├── backup_info_handler.py   # Backup info JSON read/write
 │   │   │   ├── backup_metadata_builder.py # Metadata construction
@@ -54,17 +49,13 @@ backup/
 │   │   │   ├── file_cleanup.py          # Old backup cleanup
 │   │   │   ├── file_operations.py       # File copy/move operations
 │   │   │   ├── file_scanner.py          # File discovery and filtering
-│   │   │   ├── integration_ops.py       # Integration operation logic
 │   │   │   └── path_builder.py          # Backup path construction
 │   │   ├── reporting/
 │   │   │   └── report_formatter.py      # Backup report formatting
 │   │   └── utils/
 │   │       ├── backup_timestamps.py     # Timestamp utilities
-│   │       ├── reauth_handler.py        # Re-auth implementation
 │   │       └── system_utils.py          # System-level utilities
-│   ├── extensions/              # Extension point (placeholder)
-│   ├── json_templates/          # JSON template files
-│   └── plugins/                 # Plugin point (placeholder)
+│   └── json_templates/          # JSON template files
 ├── backup_json/                 # JSON tracking data
 ├── artifacts/                   # Backup artifacts
 ├── docs/                        # Documentation
@@ -122,8 +113,6 @@ drone @backup drive-clear-tracker          # Clear Drive file tracker cache
 |--------|---------|
 | `backup_core` | Core backup operations — snapshot and versioned backup creation |
 | `google_drive_sync` | Google Drive synchronization — upload, track, and manage cloud backups |
-| `integrations` | Cross-module integration commands and coordination |
-| `reauth_drive` | Google Drive re-authentication when credentials expire |
 
 ---
 

--- a/src/aipass/backup/apps/backup.py
+++ b/src/aipass/backup/apps/backup.py
@@ -1,7 +1,7 @@
 # =================== AIPass ====================
 # Name: backup.py
 # Description: Entry point CLI for drone @backup
-# Version: 1.0.0
+# Version: 1.2.0
 # Created: 2026-03-08
 # Modified: 2026-03-08
 # =============================================
@@ -17,7 +17,8 @@ Main handles routing, modules implement functionality.
 import sys
 import argparse
 from pathlib import Path
-from typing import Any, List
+from collections.abc import Sequence
+from typing import Any
 
 from aipass.cli.apps.modules import console, error
 from aipass.prax import logger
@@ -46,20 +47,28 @@ MODULE_ROOT = Path(__file__).parent
 # COMMAND ROUTING
 # =============================================================================
 
-def route_command(args: argparse.Namespace, modules: List[Any]) -> bool:
+def route_command(args: argparse.Namespace, modules: Sequence[Any], pre_scanned=None) -> bool:
     """
     Route command to appropriate module
 
     Args:
         args: Parsed command line arguments
         modules: List of discovered modules
+        pre_scanned: Optional pre-scanned file list to pass through to backup_core.
 
     Returns:
         True if command was handled
     """
     for module in modules:
         try:
-            if module.handle_command(args):
+            if pre_scanned:
+                try:
+                    handled = module.handle_command(args, pre_scanned=pre_scanned)
+                except TypeError:
+                    handled = module.handle_command(args)
+            else:
+                handled = module.handle_command(args)
+            if handled:
                 return True
         except Exception as e:
             # Show the actual error — don't mask it behind "Unknown command"
@@ -106,7 +115,7 @@ def print_introspection():
 
 def show_version():
     """Print version from META DATA HEADER."""
-    console.print("BACKUP_SYSTEM v1.2.0")
+    console.print("backup v1.2.0")
 
 
 def main():
@@ -120,7 +129,7 @@ def main():
     # 2. Universal flags (checked before command routing, execute and exit)
     if sys.argv[1] in ['--help', '-h', 'help']:
         console.print()
-        console.print("[bold cyan]BACKUP_SYSTEM[/bold cyan] — Automated File Protection")
+        console.print("[bold cyan]backup[/bold cyan] — Automated File Protection")
         console.print()
         console.print("[yellow]Commands:[/yellow]")
         console.print("  --all             Run snapshot + versioned + drive-sync (full backup cycle)")
@@ -153,7 +162,7 @@ def main():
 
     # 3. Parse args (behavioral flags handled by argparse)
     parser = argparse.ArgumentParser(
-        description='backup_system Branch Operations',
+        description='backup Branch Operations',
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument('command', nargs='?', help='Command to execute')
@@ -184,13 +193,36 @@ def main():
         console.print("[bold cyan]Full Backup Cycle: snapshot → versioned → drive-sync[/bold cyan]")
         console.print()
 
-        # Step 1: Snapshot
+        # Scan files ONCE and share between snapshot + versioned (saves ~20s)
+        console.print("[dim]Scanning files...[/dim]")
+        from aipass.backup.apps.handlers.operations.file_scanner import scan_files
+        from aipass.backup.apps.handlers.config.config_handler import (
+            GLOBAL_IGNORE_PATTERNS, IGNORE_EXCEPTIONS, SOURCE_WHITELIST, MAX_FILE_SIZE_MB,
+            should_ignore,
+        )
+        from pathlib import Path as _Path
+
+        _source_dir = _Path.home()
+        _backup_dest = _Path(__file__).resolve().parents[1] / "backups"
+
+        def _should_ignore(path):
+            return should_ignore(path, GLOBAL_IGNORE_PATTERNS, IGNORE_EXCEPTIONS, _backup_dest)
+
+        pre_scanned = scan_files(
+            _source_dir, _should_ignore,
+            whitelist=SOURCE_WHITELIST,
+            max_file_size_mb=MAX_FILE_SIZE_MB,
+        )
+        console.print(f"[dim]Found {len(pre_scanned[0])} files to process[/dim]")
+        console.print()
+
+        # Step 1: Snapshot (reuses pre-scanned files)
         snapshot_args = argparse.Namespace(
             command='snapshot', path=None, verbose=args.verbose,
             note=args.note, dry_run=args.dry_run, project=args.project,
             force=args.force, test=False, limit=0
         )
-        if not route_command(snapshot_args, modules):
+        if not route_command(snapshot_args, modules, pre_scanned=pre_scanned):
             error("Snapshot failed - aborting")
             return 1
 
@@ -198,13 +230,13 @@ def main():
         console.print("[dim]─── snapshot complete, starting versioned ───[/dim]")
         console.print()
 
-        # Step 2: Versioned
+        # Step 2: Versioned (reuses pre-scanned files)
         versioned_args = argparse.Namespace(
             command='versioned', path=None, verbose=args.verbose,
             note=args.note, dry_run=args.dry_run, project=args.project,
             force=args.force, test=False, limit=0
         )
-        if not route_command(versioned_args, modules):
+        if not route_command(versioned_args, modules, pre_scanned=pre_scanned):
             error("Versioned backup failed - aborting")
             return 1
 
@@ -212,15 +244,18 @@ def main():
         console.print("[dim]─── versioned complete, starting drive-sync ───[/dim]")
         console.print()
 
-        # Step 3: Drive sync
-        sync_args = argparse.Namespace(
-            command='drive-sync', path=None, verbose=args.verbose,
-            note=args.note, dry_run=args.dry_run, project=args.project,
-            force=args.force, test=False, limit=args.limit
-        )
-        if not route_command(sync_args, modules):
-            error("Drive sync failed")
-            return 1
+        # Step 3: Drive sync (skip in dry-run — no point uploading nothing)
+        if args.dry_run:
+            console.print("[dim]Drive sync skipped (dry-run mode)[/dim]")
+        else:
+            sync_args = argparse.Namespace(
+                command='drive-sync', path=None, verbose=args.verbose,
+                note=args.note, dry_run=args.dry_run, project=args.project,
+                force=args.force, test=False, limit=args.limit
+            )
+            if not route_command(sync_args, modules):
+                error("Drive sync failed")
+                return 1
 
         console.print()
         console.print("[green]Full backup cycle complete[/green]")

--- a/src/aipass/backup/apps/handlers/json/backup_info_handler.py
+++ b/src/aipass/backup/apps/handlers/json/backup_info_handler.py
@@ -22,11 +22,30 @@ Functions:
 # =============================================
 
 import json
+import os
 import datetime
+import tempfile
 from pathlib import Path
 from typing import Dict
 
 from aipass.prax import logger
+
+
+def _atomic_write(file_path: Path, data: dict) -> None:
+    """Write JSON atomically via temp file + rename."""
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(suffix='.tmp', dir=str(file_path.parent))
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        os.replace(tmp_path, str(file_path))
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError as cleanup_err:
+            logger.warning(f"[backup_info_handler] Failed to clean temp file: {cleanup_err}")
+        raise
+
 
 # =============================================
 # BACKUP INFO OPERATIONS
@@ -67,8 +86,7 @@ def save_backup_info(backup_info_file: Path, backup_info: Dict) -> bool:
         True if save succeeded, False otherwise
     """
     try:
-        with open(backup_info_file, 'w', encoding='utf-8') as f:
-            json.dump(backup_info, f, indent=2, ensure_ascii=False)
+        _atomic_write(backup_info_file, backup_info)
         return True
     except Exception as e:
         logger.warning(f"[backup_info_handler] Failed to save backup info to {backup_info_file}: {e}")

--- a/src/aipass/backup/apps/handlers/json/changelog_handler.py
+++ b/src/aipass/backup/apps/handlers/json/changelog_handler.py
@@ -24,12 +24,29 @@ Functions:
 
 import datetime
 import json
+import os
+import tempfile
 from pathlib import Path
 from typing import Dict
 
 from aipass.prax import logger
 
-# logger imported from aipass.prax
+
+def _atomic_write(file_path: Path, data: dict) -> None:
+    """Write JSON atomically via temp file + rename."""
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(suffix='.tmp', dir=str(file_path.parent))
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        os.replace(tmp_path, str(file_path))
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError as cleanup_err:
+            logger.warning(f"[changelog_handler] Failed to clean temp file: {cleanup_err}")
+        raise
+
 
 # =============================================
 # CHANGELOG OPERATIONS
@@ -76,8 +93,7 @@ def save_changelog_entry(changelog_file: Path, note: str, mode: str,
         }
         changelog["entries"].append(new_entry)
 
-        with open(changelog_file, 'w', encoding='utf-8') as f:
-            json.dump(changelog, f, indent=2, ensure_ascii=False)
+        _atomic_write(changelog_file, changelog)
         logger.info(f"[changelog_handler] Saved changelog entry: {note[:50]}")
         return True
     except Exception as e:

--- a/src/aipass/backup/apps/handlers/json/drive_sync_json.py
+++ b/src/aipass/backup/apps/handlers/json/drive_sync_json.py
@@ -158,7 +158,23 @@ def load_log(log_file: Path, max_retries: int = 3) -> Dict[str, Any]:
     for attempt in range(max_retries):
         try:
             if log_file.exists() and log_file.stat().st_size > 0:
-                return _read_json_locked(log_file)
+                raw = _read_json_locked(log_file)
+                # Validate structure — legacy files may be a bare list
+                if isinstance(raw, dict) and "entries" in raw and "summary" in raw:
+                    return raw
+                # Migrate legacy list format to new structure
+                if isinstance(raw, list):
+                    logger.info(f"[drive_sync_json] Migrating legacy log format for {log_file}")
+                    migrated = dict(default_log)
+                    migrated["entries"] = raw[:100]
+                    migrated["summary"]["total_entries"] = len(raw)
+                    migrated["summary"]["next_id"] = len(raw) + 1
+                    save_log(log_file, migrated)
+                    return migrated
+                # Unknown structure — reset
+                logger.warning(f"[drive_sync_json] Unexpected log structure in {log_file}, resetting")
+                save_log(log_file, default_log)
+                return default_log
             else:
                 save_log(log_file, default_log)
                 return default_log

--- a/src/aipass/backup/apps/handlers/json/json_handler.py
+++ b/src/aipass/backup/apps/handlers/json/json_handler.py
@@ -7,7 +7,9 @@
 # =============================================
 
 import json
+import os
 import inspect
+import tempfile
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Any, Optional
@@ -17,6 +19,22 @@ from aipass.prax import logger
 # Constants
 _BACKUP_ROOT = Path(__file__).resolve().parents[3]  # src/aipass/backup/
 BACKUP_JSON_DIR = _BACKUP_ROOT / "backup_json"
+
+
+def _atomic_json_write(file_path: Path, data: Any) -> None:
+    """Write JSON atomically via temp file + rename to prevent corruption."""
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(suffix='.tmp', dir=str(file_path.parent))
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        os.replace(tmp_path, str(file_path))
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError as cleanup_err:
+            logger.warning(f"[json_handler] Failed to clean up temp file: {cleanup_err}")
+        raise
 
 
 def _get_caller_module_name() -> str:
@@ -108,24 +126,32 @@ def ensure_json_exists(module_name: str, json_type: str) -> bool:
 
     template = _get_default_template(json_type, module_name)
 
-    with open(json_path, 'w', encoding='utf-8') as f:
-        json.dump(template, f, indent=2, ensure_ascii=False)
+    _atomic_json_write(json_path, template)
     return True
 
 
 def load_json(module_name: str, json_type: str) -> Optional[Any]:
-    """Load JSON file, auto-create if missing"""
+    """Load JSON file, auto-create if missing. Self-heals corrupt files."""
     if not ensure_json_exists(module_name, json_type):
         return None
 
     json_path = get_json_path(module_name, json_type)
 
-    with open(json_path, 'r', encoding='utf-8') as f:
-        return json.load(f)
+    try:
+        with open(json_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception as e:
+        logger.warning(f"[json_handler] Corrupt JSON at {json_path}, regenerating: {e}")
+        template = _get_default_template(json_type, module_name)
+        try:
+            _atomic_json_write(json_path, template)
+        except Exception as write_err:
+            logger.error(f"[json_handler] Failed to regenerate {json_path}: {write_err}")
+        return template
 
 
 def save_json(module_name: str, json_type: str, data: Any) -> bool:
-    """Save JSON file"""
+    """Save JSON file atomically."""
     json_path = get_json_path(module_name, json_type)
 
     if not validate_json_structure(data, json_type):
@@ -134,8 +160,7 @@ def save_json(module_name: str, json_type: str, data: Any) -> bool:
     if json_type == "data" and isinstance(data, dict):
         data["last_updated"] = datetime.now().date().isoformat()
 
-    with open(json_path, 'w', encoding='utf-8') as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
+    _atomic_json_write(json_path, data)
     return True
 
 
@@ -241,7 +266,7 @@ if __name__ == "__main__":
         border_style="bright_blue"
     ))
     console.print()
-    console.print("[yellow]TESTING:[/yellow] Creating BACKUP_SYSTEM JSONs...")
+    console.print("[yellow]TESTING:[/yellow] Creating backup JSONs...")
 
     # Test auto-creation
     log_operation("test_operation", {"test": "data"}, "backup_system")

--- a/src/aipass/backup/apps/handlers/operations/drive_sync_client.py
+++ b/src/aipass/backup/apps/handlers/operations/drive_sync_client.py
@@ -18,8 +18,6 @@ Called exclusively by the google_drive_sync module orchestrator.
 # IMPORTS
 # =============================================
 
-import sys
-import ssl
 import time
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -29,22 +27,20 @@ from typing import Optional, Dict, Any
 
 from aipass.prax import logger
 
-# Google API imports (optional — not installed in every environment)
+# Google Drive service from API branch
 try:
-    from googleapiclient.discovery import build  # type: ignore[import-unresolved]
+    from aipass.api.apps.modules.google_client import (
+        get_drive_service,
+        api_call_with_retry as _api_retry,
+    )
     from googleapiclient.http import MediaFileUpload  # type: ignore[import-unresolved]
-    from google.auth.transport.requests import Request  # type: ignore[import-unresolved]
-    from google.oauth2.credentials import Credentials  # type: ignore[import-unresolved]
-    from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore[import-unresolved]
     GOOGLE_API_AVAILABLE = True
 except ImportError as e:
     logger.info(f"Google API libraries not available: {e}")
     GOOGLE_API_AVAILABLE = False
-    build = None  # type: ignore[assignment]
+    get_drive_service = None  # type: ignore[assignment]
+    _api_retry = None  # type: ignore[assignment]
     MediaFileUpload = None  # type: ignore[assignment]
-    Request = None  # type: ignore[assignment]
-    Credentials = None  # type: ignore[assignment]
-    InstalledAppFlow = None  # type: ignore[assignment]
 
 # JSON handler for data persistence
 from aipass.backup.apps.handlers.json.drive_sync_json import (
@@ -99,10 +95,6 @@ class GoogleDriveSync:
         self.config = _load_config()
         self.data = _load_data()
 
-        # Paths
-        self.creds_path = Path.home() / '.aipass' / 'drive_creds.json'
-        self.client_secrets_path = Path(__file__).parent.parent / 'credentials.json'
-
         # Runtime state
         self._drive_service = None
         self._thread_local = threading.local()
@@ -114,11 +106,15 @@ class GoogleDriveSync:
         self.last_error = None  # Last error message for callers
         self.tracker_was_reset = False  # Set True when new folder = tracker invalidated
 
-        # Check if Google API is available
+        # Sync enabled flag with actual library availability
         if not GOOGLE_API_AVAILABLE:
-
-            self.config["config"]["enabled"] = False
-            _save_config(self.config)
+            if self.config.get("config", {}).get("enabled", True):
+                self.config.setdefault("config", {})["enabled"] = False
+                _save_config(self.config)
+        else:
+            if not self.config.get("config", {}).get("enabled", True):
+                self.config.setdefault("config", {})["enabled"] = True
+                _save_config(self.config)
 
     @property
     def drive_service(self):
@@ -131,87 +127,28 @@ class GoogleDriveSync:
         self._drive_service = value
 
     def authenticate(self) -> bool:
-        """Authenticate with Google Drive using OAuth credentials"""
+        """Authenticate with Google Drive via API branch."""
         json_handler.log_operation("drive_authenticate_started")
 
         if not GOOGLE_API_AVAILABLE:
-            python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
-
-
             return False
 
         start_time = datetime.now()
-        creds = None
-
-        # Load existing credentials if they exist
-        if self.creds_path.exists():
-            try:
-                creds = Credentials.from_authorized_user_file(str(self.creds_path), SCOPES)  # type: ignore[union-attr]
-            except Exception as e:
-                logger.warning(f"Failed to load credentials from {self.creds_path}: {e}")
-                creds = None
-
-        # If no valid credentials, start OAuth flow
-        if not creds or not creds.valid:
-            if creds and creds.expired and creds.refresh_token:
-                try:
-                    creds.refresh(Request())  # type: ignore[misc]
-
-                except Exception as e:
-                    logger.warning(f"Failed to refresh credentials: {e}")
-                    creds = None
-
-            if not creds:
-                # Check if client secrets file exists
-                if not self.client_secrets_path.exists():
-
-
-                    return False
-
-                try:
-
-
-                    flow = InstalledAppFlow.from_client_secrets_file(  # type: ignore[union-attr]
-                        str(self.client_secrets_path), SCOPES
-                    )
-                    creds = flow.run_local_server(port=0)
-
-                except Exception as e:
-                    logger.warning(f"OAuth flow failed: {e}")
-                    _log_operation("authenticate", {"message": f"OAuth flow failed: {e}", "error_details": {"exception_type": type(e).__name__, "stack_trace": str(e)}}, success=False)
-                    return False
-
-        # Save credentials for next time
         try:
-            # Create .aipass directory if it doesn't exist
-            self.creds_path.parent.mkdir(parents=True, exist_ok=True)
+            self.drive_service = get_drive_service()  # type: ignore[misc]
 
-            # Save credentials
-            with open(self.creds_path, 'w', encoding='utf-8') as f:
-                f.write(creds.to_json())
-
-        except Exception as e:
-            logger.warning(f"Failed to save credentials to {self.creds_path}: {e}")
-
-        # Build Drive service
-        try:
-            self.creds = creds  # Store for building per-thread services
-            self.drive_service = build('drive', 'v3', credentials=creds)  # type: ignore[misc]
-
-            # Update runtime state (ensure runtime_state exists first)
+            # Update runtime state
             if "runtime_state" not in self.data:
                 self.data["runtime_state"] = {}
             self.data["runtime_state"]["authenticated"] = True
             _save_data(self.data)
 
-            # Log successful authentication
             execution_time = int((datetime.now() - start_time).total_seconds() * 1000)
-            _log_operation("authenticate", {"message": "Successfully authenticated with Google Drive", "execution_time_ms": execution_time}, success=True)
-
+            _log_operation("authenticate", {"message": "Authenticated via API branch", "execution_time_ms": execution_time}, success=True)
             return True
         except Exception as e:
-            logger.warning(f"Failed to build Drive service: {e}")
-            _log_operation("authenticate", {"message": f"Failed to build Drive service: {e}", "error_details": {"exception_type": type(e).__name__, "stack_trace": str(e)}}, success=False)
+            logger.warning(f"Drive authentication failed: {e}")
+            _log_operation("authenticate", {"message": f"Auth failed: {e}"}, success=False)
             return False
 
     def _verify_folder_id(self, folder_id: str) -> bool:
@@ -572,47 +509,18 @@ class GoogleDriveSync:
         _save_data(self.data)
 
     def _build_thread_service(self):
-        """Build a separate Drive service instance for use in a worker thread.
-
-        Loads fresh credentials from disk to avoid sharing credential state
-        (token refresh races) and creates a fully isolated HTTP/SSL connection.
-        """
-        creds = Credentials.from_authorized_user_file(str(self.creds_path), SCOPES)  # type: ignore[union-attr]
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())  # type: ignore[misc]
-        return build('drive', 'v3', credentials=creds)  # type: ignore[misc]
-
-    @staticmethod
-    def _is_ssl_error(exc: Exception) -> bool:
-        """Check if an exception is a transient SSL/connection error."""
-        if isinstance(exc, (ssl.SSLError, BrokenPipeError, ConnectionResetError)):
-            return True
-        ssl_keywords = (
-            'DECRYPTION_FAILED_OR_BAD_RECORD_MAC',
-            'WRONG_VERSION_NUMBER',
-            'EOF occurred',
-            'ssl.SSLError',
-            'BrokenPipeError',
-            'ConnectionReset',
-        )
-        msg = str(exc)
-        return any(kw in msg for kw in ssl_keywords)
+        """Build a thread-safe Drive service via API branch."""
+        return get_drive_service(thread_safe=True)  # type: ignore[misc]
 
     def _api_call_with_retry(self, request: Any, max_retries: int = 3) -> Dict[str, Any]:
-        """Execute a Google API request with exponential backoff on SSL errors."""
-        for attempt in range(max_retries + 1):
-            try:
-                return request.execute()
-            except Exception as e:
-                if attempt < max_retries and self._is_ssl_error(e):
-                    wait = 2 ** attempt
-
-                    time.sleep(wait)
-                    # Rebuild this thread's service on SSL failure
-                    self._thread_local.service = self._build_thread_service()
-                    continue
-                raise
-        raise RuntimeError("Retries exhausted")
+        """Execute a Google API request with retry via API branch."""
+        try:
+            return _api_retry(request, max_retries=max_retries)  # type: ignore[misc]
+        except Exception as e:
+            # On failure, rebuild thread service and retry once
+            logger.warning(f"[drive_sync_client] API call failed, rebuilding service: {e}")
+            self._thread_local.service = self._build_thread_service()
+            return _api_retry(request, max_retries=1)  # type: ignore[misc]
 
     def _check_file_needs_upload_local(self, local_file: Path, backup_root: Path) -> bool:
         """Check if file needs upload using local tracker (no API calls)"""

--- a/src/aipass/backup/apps/handlers/utils/backup_timestamps.py
+++ b/src/aipass/backup/apps/handlers/utils/backup_timestamps.py
@@ -14,6 +14,8 @@ backup command can display how fresh each backup type is.
 """
 
 import json
+import os
+import tempfile
 from pathlib import Path
 from datetime import datetime
 
@@ -61,7 +63,17 @@ def update_timestamp(mode: str) -> None:
     data[mode] = datetime.now().isoformat()
 
     TIMESTAMPS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    TIMESTAMPS_FILE.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    fd, tmp_path = tempfile.mkstemp(suffix='.tmp', dir=str(TIMESTAMPS_FILE.parent))
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, str(TIMESTAMPS_FILE))
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError as cleanup_err:
+            logger.warning(f"[backup_timestamps] Failed to clean temp file: {cleanup_err}")
+        raise
 
 
 def format_age(iso_str: str | None) -> str:

--- a/src/aipass/backup/apps/modules/backup_core.py
+++ b/src/aipass/backup/apps/modules/backup_core.py
@@ -133,7 +133,7 @@ def print_help():
     console.print()
 
 
-def handle_command(args) -> bool:
+def handle_command(args, pre_scanned=None) -> bool:
     """Route backup commands to appropriate handler.
 
     This is the module-level entry point for CLI commands related to backup.
@@ -141,6 +141,7 @@ def handle_command(args) -> bool:
 
     Args:
         args: Command-line arguments from CLI parser
+        pre_scanned: Optional pre-scanned file list tuple to avoid duplicate scans.
 
     Returns:
         bool: True if command was handled, False if not a backup command
@@ -161,7 +162,7 @@ def handle_command(args) -> bool:
     if args.command not in ['snapshot', 'versioned', 'all']:
         return False
 
-    # 'all' is orchestrated by backup_system.py entry point (snapshot → versioned → drive-sync)
+    # 'all' is orchestrated by backup.py entry point (snapshot → versioned → drive-sync)
     if args.command == 'all':
         return False
 
@@ -183,7 +184,7 @@ def handle_command(args) -> bool:
     try:
         # Create engine and run backup
         engine = BackupEngine(mode, dry_run=dry_run)
-        result = engine.run_backup(backup_note)
+        result = engine.run_backup(backup_note, pre_scanned=pre_scanned)
 
         # Rich summary
         duration = (datetime.datetime.now() - result.start_time).total_seconds()
@@ -352,13 +353,15 @@ class BackupEngine:
     # MAIN BACKUP EXECUTION
     # =============================================
 
-    def run_backup(self, backup_note: str = "No note provided") -> BackupResult:
+    def run_backup(self, backup_note: str = "No note provided", pre_scanned=None) -> BackupResult:
         """Execute backup - thin orchestration layer calling handlers.
 
         Coordinates backup workflow by delegating to specialized handlers.
 
         Args:
             backup_note: User note describing backup purpose/context
+            pre_scanned: Optional tuple of (files_to_backup, skipped_items) from a
+                previous scan. Used by the 'all' command to avoid scanning twice.
 
         Returns:
             BackupResult: Complete operation result with statistics and status
@@ -396,13 +399,16 @@ class BackupEngine:
         if not isinstance(last_timestamps, dict):
             last_timestamps = {}
 
-        # HANDLER: Scan files
-        from aipass.backup.apps.handlers.operations.file_scanner import scan_files
-        files_to_backup, skipped_items = scan_files(
-            self.source_dir, self.should_ignore,
-            whitelist=SOURCE_WHITELIST,
-            max_file_size_mb=MAX_FILE_SIZE_MB
-        )
+        # HANDLER: Scan files (reuse pre_scanned if provided by 'all' command)
+        if pre_scanned:
+            files_to_backup, skipped_items = pre_scanned
+        else:
+            from aipass.backup.apps.handlers.operations.file_scanner import scan_files
+            files_to_backup, skipped_items = scan_files(
+                self.source_dir, self.should_ignore,
+                whitelist=SOURCE_WHITELIST,
+                max_file_size_mb=MAX_FILE_SIZE_MB
+            )
 
         # HANDLER: Process files
         from aipass.backup.apps.handlers.operations.path_builder import build_backup_path
@@ -528,10 +534,7 @@ class BackupEngine:
             console.print(f"  [dim]Versioned:  {format_age(ts.get('versioned'))}[/dim]")
             console.print(f"  [dim]Drive sync: {format_age(ts.get('drive_sync'))}[/dim]")
 
-            # Integration hooks (stubs - implement in handlers/integrations/)
-            if self.mode == 'versioned':
-                logger.info("[backup_core] Drive sync skipped (not implemented)")
-            logger.info("[backup_core] Read-only protection skipped (not implemented)")
+            # Drive sync runs separately via 'all' command in backup.py entry point
         else:
             json_handler.log_operation(
                 "backup",
@@ -572,6 +575,6 @@ if __name__ == "__main__":
         print_help()
         sys.exit(0)
 
-    console.print("[yellow]Note:[/yellow] Run via backup_system.py entry point for full functionality")
+    console.print("[yellow]Note:[/yellow] Run via drone @backup for full functionality")
     console.print()
     print_introspection()

--- a/src/aipass/backup/apps/modules/google_drive_sync.py
+++ b/src/aipass/backup/apps/modules/google_drive_sync.py
@@ -291,12 +291,14 @@ def handle_command(args) -> bool:
         return True
 
     if command == 'drive-test':
-        return _test_drive_sync()
+        _test_drive_sync()
+        return True
 
     elif command == 'drive-sync':
         # --test flag routes to test mode
         if getattr(args, 'test', False):
-            return _run_sync_test()
+            _run_sync_test()
+            return True
 
         raw_path = getattr(args, 'path', None)
         if raw_path:
@@ -306,7 +308,7 @@ def handle_command(args) -> bool:
             backup_path = _BACKUP_ROOT / "backups" / "system_snapshot"
         if not backup_path.exists():
             error(f"Backup directory not found: {backup_path}")
-            return False
+            return True  # Command was recognized, just failed
 
         project = getattr(args, 'project', 'AIPass') or 'AIPass'
         note = getattr(args, 'note', 'Manual sync') or 'Manual sync'
@@ -314,11 +316,11 @@ def handle_command(args) -> bool:
 
         if GoogleDriveSync is None:
             error("Drive sync dependencies not available")
-            return False
+            return True  # Command was recognized, just failed
         sync = GoogleDriveSync()
         if not sync.authenticate():
             error("FAILED: Could not authenticate with Google Drive")
-            return False
+            return True  # Command was recognized, just failed
 
         limit = getattr(args, 'limit', 0) or 0
 
@@ -339,7 +341,7 @@ def handle_command(args) -> bool:
             error_msg = sync.last_error or "Unknown error"
             error(f"FAILED: {error_msg}")
             error("Sync aborted - no files uploaded")
-            return False
+            return True  # Command was recognized, just failed
         console.print(f"  Drive folder ready: {project}")
 
         if sync.tracker_was_reset:
@@ -393,7 +395,7 @@ def handle_command(args) -> bool:
         if result.get("error"):
             error(f"FAILED: {result['error']}")
             error("Sync aborted - no files uploaded")
-            return False
+            return True  # Command was recognized, just failed
 
         # Summary
         console.print()
@@ -410,16 +412,15 @@ def handle_command(args) -> bool:
         else:
             error(f"Sync failed: {result['uploaded']} uploaded, {result['failed']} failed, {result['skipped']} unchanged")
 
-        return result["success"]
-
-    elif command == 'drive-sync-test':
-        return _run_sync_test()
+        return True  # Command was handled; success/failure shown to user above
 
     elif command == 'drive-clear-tracker':
-        return _clear_file_tracker()
+        _clear_file_tracker()
+        return True
 
     elif command == 'drive-stats':
-        return _show_file_tracker_stats()
+        _show_file_tracker_stats()
+        return True
 
     json_handler.log_operation("drive_command", {"command": command})
     return False

--- a/src/aipass/backup/tests/conftest.py
+++ b/src/aipass/backup/tests/conftest.py
@@ -1,11 +1,10 @@
 """Shared pytest fixtures for backup branch tests."""
-import json
 import pytest
 import shutil
 import sys
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 from unittest.mock import MagicMock
 
 
@@ -55,43 +54,6 @@ def temp_test_dir() -> Generator[Path, None, None]:
 
 
 @pytest.fixture
-def sample_source_tree(tmp_path):
-    """Creates a realistic source directory tree for backup testing."""
-    source = tmp_path / "source"
-    source.mkdir()
-
-    # Create some files
-    (source / "file1.txt").write_text("hello world", encoding="utf-8")
-    (source / "file2.py").write_text("print('hello')", encoding="utf-8")
-
-    # Nested structure
-    sub = source / "subdir"
-    sub.mkdir()
-    (sub / "nested.json").write_text('{"key": "value"}', encoding="utf-8")
-    (sub / "deep" / "deeper").mkdir(parents=True)
-    (sub / "deep" / "deeper" / "bottom.txt").write_text("bottom", encoding="utf-8")
-
-    return source
-
-
-@pytest.fixture
-def sample_backup_dir(tmp_path):
-    """Creates a backup destination directory."""
-    backup = tmp_path / "backup_dest"
-    backup.mkdir()
-    return backup
-
-
-@pytest.fixture
-def sample_test_data() -> dict:
-    """Provides sample test data."""
-    return {
-        "test_key": "test_value",
-        "sample_data": "example"
-    }
-
-
-@pytest.fixture
 def mock_json_handler(monkeypatch):
     """Creates a mock json_handler that can be injected into modules."""
     mock = MagicMock()
@@ -100,22 +62,3 @@ def mock_json_handler(monkeypatch):
     mock.load_json = MagicMock(return_value={})
     mock.save_json = MagicMock(return_value=True)
     return mock
-
-
-@pytest.fixture
-def mock_backup_result():
-    """Creates a mock BackupResult for testing operations."""
-    result = MagicMock()
-    result.files_checked = 0
-    result.files_copied = 0
-    result.files_added = 0
-    result.files_skipped = 0
-    result.files_deleted = 0
-    result.errors = 0
-    result.error_details = []
-    result.warnings = []
-    result.critical_errors = []
-    result.success = True
-    result.add_error = MagicMock()
-    result.add_warning = MagicMock()
-    return result

--- a/src/aipass/backup/tests/test_backup_metadata_builder.py
+++ b/src/aipass/backup/tests/test_backup_metadata_builder.py
@@ -1,0 +1,234 @@
+"""Tests for backup_metadata_builder — backup metadata construction."""
+
+import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+class TestCreateBackupMetadataVersioned:
+    """create_backup_metadata with versioned behavior appends to backup list."""
+
+    def test_versioned_inserts_at_front(self):
+        """New backup entry is inserted at position 0 in the backups list."""
+        from aipass.backup.apps.handlers.json.backup_metadata_builder import (
+            create_backup_metadata,
+        )
+
+        result = MagicMock()
+        result.files_checked = 10
+        result.files_copied = 5
+        result.files_added = 2
+        result.files_skipped = 3
+        result.errors = 0
+
+        existing = {"backups": [{"backup_name": "old"}]}
+
+        info = create_backup_metadata(
+            mode="versioned",
+            behavior="versioned",
+            backup_note="test note",
+            backup_folder_name="v1",
+            backup_path=Path("/tmp/backup/v1"),
+            source_dir=Path("/src"),
+            result=result,
+            current_timestamps={},
+            existing_backup_info=existing,
+        )
+
+        assert len(info["backups"]) == 2
+        assert info["backups"][0]["backup_name"] == "v1"
+        assert info["backups"][1]["backup_name"] == "old"
+
+    def test_versioned_entry_contains_stats(self):
+        """Versioned entry includes all expected stat fields."""
+        from aipass.backup.apps.handlers.json.backup_metadata_builder import (
+            create_backup_metadata,
+        )
+
+        result = MagicMock()
+        result.files_checked = 20
+        result.files_copied = 15
+        result.files_added = 4
+        result.files_skipped = 1
+        result.errors = 2
+
+        existing = {"backups": []}
+
+        info = create_backup_metadata(
+            mode="versioned",
+            behavior="versioned",
+            backup_note="stats check",
+            backup_folder_name="v2",
+            backup_path=Path("/tmp/v2"),
+            source_dir=Path("/src"),
+            result=result,
+            current_timestamps={},
+            existing_backup_info=existing,
+        )
+
+        stats = info["backups"][0]["stats"]
+        assert stats["files_checked"] == 20
+        assert stats["files_copied"] == 15
+        assert stats["files_added"] == 4
+        assert stats["files_skipped"] == 1
+        assert stats["errors"] == 2
+
+    def test_versioned_entry_has_timestamp(self):
+        """Versioned entry includes an ISO-format timestamp."""
+        from aipass.backup.apps.handlers.json.backup_metadata_builder import (
+            create_backup_metadata,
+        )
+
+        result = MagicMock()
+        result.files_checked = 0
+        result.files_copied = 0
+        result.files_added = 0
+        result.files_skipped = 0
+        result.errors = 0
+
+        existing = {"backups": []}
+
+        info = create_backup_metadata(
+            mode="versioned",
+            behavior="versioned",
+            backup_note="",
+            backup_folder_name="v3",
+            backup_path=Path("/tmp/v3"),
+            source_dir=Path("/src"),
+            result=result,
+            current_timestamps={},
+            existing_backup_info=existing,
+        )
+
+        ts = info["backups"][0]["timestamp"]
+        # Should parse without error
+        datetime.datetime.fromisoformat(ts)
+
+    def test_versioned_preserves_note_and_paths(self):
+        """Versioned entry stores backup_note, backup_path, and source_path."""
+        from aipass.backup.apps.handlers.json.backup_metadata_builder import (
+            create_backup_metadata,
+        )
+
+        result = MagicMock()
+        result.files_checked = 0
+        result.files_copied = 0
+        result.files_added = 0
+        result.files_skipped = 0
+        result.errors = 0
+
+        existing = {"backups": []}
+
+        info = create_backup_metadata(
+            mode="versioned",
+            behavior="versioned",
+            backup_note="my note",
+            backup_folder_name="v4",
+            backup_path=Path("/tmp/v4"),
+            source_dir=Path("/my/src"),
+            result=result,
+            current_timestamps={},
+            existing_backup_info=existing,
+        )
+
+        entry = info["backups"][0]
+        assert entry["backup_note"] == "my note"
+        assert entry["backup_path"] == "/tmp/v4"
+        assert entry["source_path"] == "/my/src"
+        assert entry["mode"] == "versioned"
+
+
+class TestCreateBackupMetadataDynamic:
+    """create_backup_metadata with non-versioned behavior returns flat dict."""
+
+    def test_dynamic_returns_flat_dict(self):
+        """Dynamic mode returns a dict with top-level keys (not a backups list)."""
+        from aipass.backup.apps.handlers.json.backup_metadata_builder import (
+            create_backup_metadata,
+        )
+
+        result = MagicMock()
+        result.files_checked = 8
+        result.files_copied = 4
+        result.files_added = 1
+        result.files_skipped = 3
+        result.files_deleted = 2
+        result.errors = 0
+
+        timestamps = {"file_a.txt": "2026-01-01T00:00:00"}
+
+        info = create_backup_metadata(
+            mode="snapshot",
+            behavior="dynamic",
+            backup_note="dyn note",
+            backup_folder_name="snap1",
+            backup_path=Path("/tmp/snap1"),
+            source_dir=Path("/src"),
+            result=result,
+            current_timestamps=timestamps,
+            existing_backup_info={},
+        )
+
+        assert "backups" not in info
+        assert info["backup_note"] == "dyn note"
+        assert info["mode"] == "snapshot"
+        assert info["backup_path"] == "/tmp/snap1"
+        assert info["file_timestamps"] == timestamps
+
+    def test_dynamic_includes_files_deleted(self):
+        """Dynamic mode stats include files_deleted (versioned does not)."""
+        from aipass.backup.apps.handlers.json.backup_metadata_builder import (
+            create_backup_metadata,
+        )
+
+        result = MagicMock()
+        result.files_checked = 5
+        result.files_copied = 3
+        result.files_added = 0
+        result.files_skipped = 2
+        result.files_deleted = 7
+        result.errors = 1
+
+        info = create_backup_metadata(
+            mode="snapshot",
+            behavior="dynamic",
+            backup_note="",
+            backup_folder_name="snap2",
+            backup_path=Path("/tmp/snap2"),
+            source_dir=Path("/src"),
+            result=result,
+            current_timestamps={},
+            existing_backup_info={},
+        )
+
+        stats = info["stats"]
+        assert stats["files_deleted"] == 7
+        assert stats["errors"] == 1
+
+    def test_dynamic_has_last_backup_timestamp(self):
+        """Dynamic mode includes a parseable last_backup timestamp."""
+        from aipass.backup.apps.handlers.json.backup_metadata_builder import (
+            create_backup_metadata,
+        )
+
+        result = MagicMock()
+        result.files_checked = 0
+        result.files_copied = 0
+        result.files_added = 0
+        result.files_skipped = 0
+        result.files_deleted = 0
+        result.errors = 0
+
+        info = create_backup_metadata(
+            mode="snapshot",
+            behavior="dynamic",
+            backup_note="",
+            backup_folder_name="snap3",
+            backup_path=Path("/tmp/snap3"),
+            source_dir=Path("/src"),
+            result=result,
+            current_timestamps={},
+            existing_backup_info={},
+        )
+
+        datetime.datetime.fromisoformat(info["last_backup"])

--- a/src/aipass/backup/tests/test_diff_generator.py
+++ b/src/aipass/backup/tests/test_diff_generator.py
@@ -1,0 +1,297 @@
+"""Tests for diff_generator handler."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ===================================================================
+# TestShouldCreateDiff
+# ===================================================================
+
+
+class TestShouldCreateDiff:
+    """Validate pattern-based filtering for diff creation."""
+
+    def _clear_and_import(self, monkeypatch):
+        """Clear cached diff_generator and re-import should_create_diff."""
+        for key in list(sys.modules):
+            if "diff_generator" in key:
+                monkeypatch.delitem(sys.modules, key, raising=False)
+        from aipass.backup.apps.handlers.diff.diff_generator import should_create_diff
+        return should_create_diff
+
+    def test_returns_true_for_unmatched_file(self, monkeypatch):
+        """Files not matching any pattern default to True."""
+        monkeypatch.setitem(sys.modules, "aipass.backup.apps.handlers.config.config_handler", MagicMock(
+            DIFF_IGNORE_PATTERNS=["*.bin"],
+            DIFF_INCLUDE_PATTERNS=["*.special"],
+        ))
+        should_create_diff = self._clear_and_import(monkeypatch)
+
+        result = should_create_diff(Path("src/app.py"))
+        assert result is True
+
+    def test_returns_false_for_ignored_pattern(self, monkeypatch):
+        """Files matching an ignore pattern return False."""
+        monkeypatch.setitem(sys.modules, "aipass.backup.apps.handlers.config.config_handler", MagicMock(
+            DIFF_IGNORE_PATTERNS=["*.bin", "*.lock"],
+            DIFF_INCLUDE_PATTERNS=[],
+        ))
+        should_create_diff = self._clear_and_import(monkeypatch)
+
+        result = should_create_diff(Path("data/archive.bin"))
+        assert result is False
+
+    def test_include_pattern_overrides_ignore(self, monkeypatch):
+        """Include patterns take priority over ignore patterns."""
+        monkeypatch.setitem(sys.modules, "aipass.backup.apps.handlers.config.config_handler", MagicMock(
+            DIFF_IGNORE_PATTERNS=["*.json"],
+            DIFF_INCLUDE_PATTERNS=["*.json"],
+        ))
+        should_create_diff = self._clear_and_import(monkeypatch)
+
+        result = should_create_diff(Path("config.json"))
+        assert result is True
+
+    def test_returns_true_when_no_patterns(self, monkeypatch):
+        """Empty pattern lists mean all files get diffs."""
+        monkeypatch.setitem(sys.modules, "aipass.backup.apps.handlers.config.config_handler", MagicMock(
+            DIFF_IGNORE_PATTERNS=[],
+            DIFF_INCLUDE_PATTERNS=[],
+        ))
+        should_create_diff = self._clear_and_import(monkeypatch)
+
+        result = should_create_diff(Path("anything.xyz"))
+        assert result is True
+
+    def test_returns_false_for_lock_file(self, monkeypatch):
+        """Lock files matching ignore pattern are skipped."""
+        monkeypatch.setitem(sys.modules, "aipass.backup.apps.handlers.config.config_handler", MagicMock(
+            DIFF_IGNORE_PATTERNS=["*.lock"],
+            DIFF_INCLUDE_PATTERNS=[],
+        ))
+        should_create_diff = self._clear_and_import(monkeypatch)
+
+        result = should_create_diff(Path("poetry.lock"))
+        assert result is False
+
+
+# ===================================================================
+# TestIsBinaryFile
+# ===================================================================
+
+
+class TestIsBinaryFile:
+    """Validate binary file detection."""
+
+    def _clear_and_import(self, monkeypatch):
+        """Clear cached diff_generator and re-import is_binary_file."""
+        for key in list(sys.modules):
+            if "diff_generator" in key:
+                monkeypatch.delitem(sys.modules, key, raising=False)
+        from aipass.backup.apps.handlers.diff.diff_generator import is_binary_file
+        return is_binary_file
+
+    def test_text_file_detected(self, tmp_path, monkeypatch):
+        """Plain text file is not detected as binary."""
+        is_binary_file = self._clear_and_import(monkeypatch)
+
+        text_file = tmp_path / "readme.txt"
+        text_file.write_text("Hello, world!\nThis is plain text.", encoding="utf-8")
+
+        assert is_binary_file(text_file) is False
+
+    def test_binary_file_detected(self, tmp_path, monkeypatch):
+        """File containing null bytes is detected as binary."""
+        is_binary_file = self._clear_and_import(monkeypatch)
+
+        bin_file = tmp_path / "image.png"
+        bin_file.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
+
+        assert is_binary_file(bin_file) is True
+
+    def test_empty_file_is_not_binary(self, tmp_path, monkeypatch):
+        """Empty file has no null bytes, so it is not binary."""
+        is_binary_file = self._clear_and_import(monkeypatch)
+
+        empty_file = tmp_path / "empty.txt"
+        empty_file.write_bytes(b"")
+
+        assert is_binary_file(empty_file) is False
+
+    def test_nonexistent_file_assumed_binary(self, tmp_path, monkeypatch):
+        """Unreadable/missing file defaults to binary assumption."""
+        is_binary_file = self._clear_and_import(monkeypatch)
+
+        missing = tmp_path / "no_such_file.dat"
+
+        assert is_binary_file(missing) is True
+
+    def test_null_byte_at_end_of_chunk(self, tmp_path, monkeypatch):
+        """Null byte anywhere in first 1024 bytes triggers binary detection."""
+        is_binary_file = self._clear_and_import(monkeypatch)
+
+        tricky_file = tmp_path / "tricky.dat"
+        tricky_file.write_bytes(b"A" * 1023 + b"\x00")
+
+        assert is_binary_file(tricky_file) is True
+
+    def test_null_byte_beyond_chunk_not_detected(self, tmp_path, monkeypatch):
+        """Null bytes beyond the first 1024 bytes are not checked."""
+        is_binary_file = self._clear_and_import(monkeypatch)
+
+        long_file = tmp_path / "long.dat"
+        long_file.write_bytes(b"A" * 1025 + b"\x00")
+
+        assert is_binary_file(long_file) is False
+
+
+# ===================================================================
+# TestGenerateDiffContent
+# ===================================================================
+
+
+class TestGenerateDiffContent:
+    """Validate unified diff generation between file versions."""
+
+    def _clear_and_import(self, monkeypatch):
+        """Clear cached diff_generator and re-import generate_diff_content."""
+        for key in list(sys.modules):
+            if "diff_generator" in key:
+                monkeypatch.delitem(sys.modules, key, raising=False)
+        from aipass.backup.apps.handlers.diff.diff_generator import generate_diff_content
+        return generate_diff_content
+
+    def test_generates_diff_for_changed_file(self, tmp_path, monkeypatch):
+        """Produces unified diff output for text files with differences."""
+        generate_diff_content = self._clear_and_import(monkeypatch)
+
+        old = tmp_path / "old.txt"
+        new = tmp_path / "new.txt"
+        old.write_text("line1\nline2\n", encoding="utf-8")
+        new.write_text("line1\nline2_modified\n", encoding="utf-8")
+
+        result = generate_diff_content(old, new)
+
+        assert "---" in result
+        assert "+++" in result
+        assert "-line2" in result
+        assert "+line2_modified" in result
+
+    def test_identical_files_produce_empty_diff(self, tmp_path, monkeypatch):
+        """No diff output when files are identical."""
+        generate_diff_content = self._clear_and_import(monkeypatch)
+
+        old = tmp_path / "same.txt"
+        new = tmp_path / "same_copy.txt"
+        old.write_text("identical content\n", encoding="utf-8")
+        new.write_text("identical content\n", encoding="utf-8")
+
+        result = generate_diff_content(old, new)
+
+        assert result == ""
+
+    def test_binary_files_return_message(self, tmp_path, monkeypatch):
+        """Binary files produce a descriptive message instead of diff."""
+        generate_diff_content = self._clear_and_import(monkeypatch)
+
+        old = tmp_path / "old.bin"
+        new = tmp_path / "new.bin"
+        old.write_bytes(b"\x00\x01\x02")
+        new.write_bytes(b"\x00\x01\x03")
+
+        result = generate_diff_content(old, new)
+
+        assert "Binary file" in result
+        assert "old.bin" in result
+
+    def test_one_binary_one_text_returns_binary_message(self, tmp_path, monkeypatch):
+        """Mixed binary/text pair still returns binary message."""
+        generate_diff_content = self._clear_and_import(monkeypatch)
+
+        old = tmp_path / "mixed.bin"
+        new = tmp_path / "mixed.txt"
+        old.write_bytes(b"\x00binary content")
+        new.write_text("text content\n", encoding="utf-8")
+
+        result = generate_diff_content(old, new)
+
+        assert "Binary file" in result
+
+    def test_new_file_content_shows_additions(self, tmp_path, monkeypatch):
+        """Diff from empty old file shows all lines as additions."""
+        generate_diff_content = self._clear_and_import(monkeypatch)
+
+        old = tmp_path / "empty.txt"
+        new = tmp_path / "filled.txt"
+        old.write_text("", encoding="utf-8")
+        new.write_text("new line 1\nnew line 2\n", encoding="utf-8")
+
+        result = generate_diff_content(old, new)
+
+        assert "+new line 1" in result
+        assert "+new line 2" in result
+
+    def test_deleted_content_shows_removals(self, tmp_path, monkeypatch):
+        """Diff to empty new file shows all lines as removals."""
+        generate_diff_content = self._clear_and_import(monkeypatch)
+
+        old = tmp_path / "full.txt"
+        new = tmp_path / "empty.txt"
+        old.write_text("old line 1\nold line 2\n", encoding="utf-8")
+        new.write_text("", encoding="utf-8")
+
+        result = generate_diff_content(old, new)
+
+        assert "-old line 1" in result
+        assert "-old line 2" in result
+
+    def test_error_returns_error_message(self, tmp_path, monkeypatch):
+        """Unreadable file returns error string instead of raising."""
+        generate_diff_content = self._clear_and_import(monkeypatch)
+
+        old = tmp_path / "exists.txt"
+        new = tmp_path / "nonexistent.txt"
+        old.write_text("content\n", encoding="utf-8")
+        # new does not exist -- stat() will fail after binary check passes
+
+        # Patch is_binary_file to return False so we reach the read/stat path
+        with patch(
+            "aipass.backup.apps.handlers.diff.diff_generator.is_binary_file",
+            return_value=False,
+        ):
+            result = generate_diff_content(old, new)
+
+        assert "Error generating diff" in result
+
+    def test_diff_includes_file_names(self, tmp_path, monkeypatch):
+        """Diff header lines reference the correct file names."""
+        generate_diff_content = self._clear_and_import(monkeypatch)
+
+        old = tmp_path / "alpha.py"
+        new = tmp_path / "beta.py"
+        old.write_text("x = 1\n", encoding="utf-8")
+        new.write_text("x = 2\n", encoding="utf-8")
+
+        result = generate_diff_content(old, new)
+
+        assert "a/alpha.py" in result
+        assert "b/beta.py" in result
+
+    def test_logs_operation_on_success(self, tmp_path, monkeypatch):
+        """json_handler.log_operation is called on successful diff generation."""
+        generate_diff_content = self._clear_and_import(monkeypatch)
+
+        old = tmp_path / "a.txt"
+        new = tmp_path / "b.txt"
+        old.write_text("one\n", encoding="utf-8")
+        new.write_text("two\n", encoding="utf-8")
+
+        # The json_handler is already mocked via conftest, just verify no crash
+        result = generate_diff_content(old, new)
+
+        assert "-one" in result
+        assert "+two" in result

--- a/src/aipass/backup/tests/test_drive_sync_json.py
+++ b/src/aipass/backup/tests/test_drive_sync_json.py
@@ -1,0 +1,272 @@
+"""Tests for drive_sync_json handler."""
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+class TestAtomicJsonWrite:
+    """Tests for atomic_json_write function."""
+
+    def test_writes_valid_json(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import atomic_json_write
+
+        test_file = tmp_path / "test.json"
+        atomic_json_write(test_file, {"key": "value"})
+        assert json.loads(test_file.read_text(encoding="utf-8")) == {"key": "value"}
+
+    def test_writes_list_data(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import atomic_json_write
+
+        test_file = tmp_path / "list.json"
+        atomic_json_write(test_file, [1, 2, 3])
+        assert json.loads(test_file.read_text(encoding="utf-8")) == [1, 2, 3]
+
+    def test_overwrites_existing_file(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import atomic_json_write
+
+        test_file = tmp_path / "overwrite.json"
+        atomic_json_write(test_file, {"old": True})
+        atomic_json_write(test_file, {"new": True})
+        assert json.loads(test_file.read_text(encoding="utf-8")) == {"new": True}
+
+    def test_writes_nested_structures(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import atomic_json_write
+
+        test_file = tmp_path / "nested.json"
+        data = {"a": {"b": {"c": [1, 2, {"d": "deep"}]}}}
+        atomic_json_write(test_file, data)
+        assert json.loads(test_file.read_text(encoding="utf-8")) == data
+
+    def test_cleans_up_temp_on_failure(self, tmp_path, monkeypatch):
+        from aipass.backup.apps.handlers.json.drive_sync_json import atomic_json_write
+        import os
+
+        test_file = tmp_path / "fail.json"
+        # Patch os.replace to raise, simulating a failure after temp write
+        monkeypatch.setattr(os, "replace", MagicMock(side_effect=OSError("replace failed")))
+
+        with pytest.raises(OSError, match="replace failed"):
+            atomic_json_write(test_file, {"key": "value"})
+
+        # Temp file should have been cleaned up
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert len(tmp_files) == 0
+
+    def test_writes_empty_dict(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import atomic_json_write
+
+        test_file = tmp_path / "empty.json"
+        atomic_json_write(test_file, {})
+        assert json.loads(test_file.read_text(encoding="utf-8")) == {}
+
+
+class TestSaveConfig:
+    """Tests for save_config function."""
+
+    def test_saves_config_to_file(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import save_config
+
+        config_file = tmp_path / "config.json"
+        config = {"setting_a": True, "setting_b": "hello"}
+        save_config(config_file, config)
+        assert json.loads(config_file.read_text(encoding="utf-8")) == config
+
+    def test_creates_parent_directories(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import save_config
+
+        config_file = tmp_path / "deep" / "nested" / "config.json"
+        save_config(config_file, {"created": True})
+        assert config_file.exists()
+        assert json.loads(config_file.read_text(encoding="utf-8")) == {"created": True}
+
+    def test_overwrites_existing_config(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import save_config
+
+        config_file = tmp_path / "config.json"
+        save_config(config_file, {"version": 1})
+        save_config(config_file, {"version": 2})
+        assert json.loads(config_file.read_text(encoding="utf-8")) == {"version": 2}
+
+
+class TestSaveData:
+    """Tests for save_data function."""
+
+    def test_saves_data_with_last_updated(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import save_data
+
+        data_file = tmp_path / "data.json"
+        save_data(data_file, {"items": [1, 2, 3]})
+        result = json.loads(data_file.read_text(encoding="utf-8"))
+        assert result["items"] == [1, 2, 3]
+        assert "last_updated" in result
+
+    def test_creates_parent_directories(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import save_data
+
+        data_file = tmp_path / "sub" / "dir" / "data.json"
+        save_data(data_file, {"key": "val"})
+        assert data_file.exists()
+
+    def test_deepcopy_protects_original(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import save_data
+
+        data_file = tmp_path / "data.json"
+        original = {"nested": {"a": 1}}
+        save_data(data_file, original)
+        # Original should not have last_updated injected
+        assert "last_updated" not in original
+
+    def test_retries_on_deepcopy_failure(self, tmp_path, monkeypatch):
+        from aipass.backup.apps.handlers.json import drive_sync_json
+        import copy
+
+        data_file = tmp_path / "data.json"
+        call_count = 0
+        original_deepcopy = copy.deepcopy
+
+        def flaky_deepcopy(obj, memo=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise RuntimeError("dictionary changed during copy")
+            return original_deepcopy(obj, memo)
+
+        monkeypatch.setattr(copy, "deepcopy", flaky_deepcopy)
+        drive_sync_json.save_data(data_file, {"retry": True})
+        result = json.loads(data_file.read_text(encoding="utf-8"))
+        assert result["retry"] is True
+        assert call_count == 3
+
+    def test_raises_after_max_deepcopy_retries(self, tmp_path, monkeypatch):
+        from aipass.backup.apps.handlers.json import drive_sync_json
+        import copy
+
+        data_file = tmp_path / "data.json"
+        monkeypatch.setattr(
+            copy, "deepcopy", MagicMock(side_effect=RuntimeError("always fails"))
+        )
+        # Patch time.sleep to avoid real delays
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        with pytest.raises(RuntimeError, match="always fails"):
+            drive_sync_json.save_data(data_file, {"fail": True})
+
+    def test_last_updated_is_valid_iso_format(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import save_data
+        from datetime import datetime
+
+        data_file = tmp_path / "data.json"
+        save_data(data_file, {"check": "timestamp"})
+        result = json.loads(data_file.read_text(encoding="utf-8"))
+        # Should parse without error
+        datetime.fromisoformat(result["last_updated"])
+
+
+class TestLoadLog:
+    """Tests for load_log function."""
+
+    def test_returns_default_when_file_missing(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import load_log
+
+        log_file = tmp_path / "log.json"
+        result = load_log(log_file)
+        assert result["entries"] == []
+        assert result["summary"]["total_entries"] == 0
+        assert result["summary"]["last_entry"] is None
+        assert result["summary"]["next_id"] == 1
+
+    def test_creates_file_when_missing(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import load_log
+
+        log_file = tmp_path / "log.json"
+        load_log(log_file)
+        assert log_file.exists()
+
+    def test_loads_existing_log(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import load_log, save_log
+
+        log_file = tmp_path / "log.json"
+        log_data = {
+            "entries": [{"id": 1, "message": "test"}],
+            "summary": {"total_entries": 1, "last_entry": "2026-01-01", "next_id": 2},
+        }
+        save_log(log_file, log_data)
+        result = load_log(log_file)
+        assert result["entries"][0]["message"] == "test"
+        assert result["summary"]["total_entries"] == 1
+
+    def test_returns_default_on_empty_file(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import load_log
+
+        log_file = tmp_path / "log.json"
+        log_file.write_text("", encoding="utf-8")
+        result = load_log(log_file)
+        assert result["entries"] == []
+        assert result["summary"]["next_id"] == 1
+
+    def test_retries_on_json_decode_error(self, tmp_path, monkeypatch):
+        from aipass.backup.apps.handlers.json import drive_sync_json
+
+        log_file = tmp_path / "log.json"
+        log_file.write_text("{invalid json", encoding="utf-8")
+        # Patch time.sleep to avoid delays
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        result = drive_sync_json.load_log(log_file, max_retries=3)
+        # After all retries fail, should return default
+        assert result["entries"] == []
+        assert result["summary"]["total_entries"] == 0
+
+    def test_returns_default_on_generic_exception(self, tmp_path, monkeypatch):
+        from aipass.backup.apps.handlers.json import drive_sync_json
+
+        log_file = tmp_path / "log.json"
+        # Create valid file but make _read_json_locked raise
+        log_file.write_text('{"entries": []}', encoding="utf-8")
+        monkeypatch.setattr(
+            drive_sync_json,
+            "_read_json_locked",
+            MagicMock(side_effect=PermissionError("no access")),
+        )
+        result = drive_sync_json.load_log(log_file)
+        assert result["entries"] == []
+
+
+class TestSaveLog:
+    """Tests for save_log function."""
+
+    def test_saves_log_data(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import save_log
+
+        log_file = tmp_path / "log.json"
+        log_data = {
+            "entries": [{"id": 1, "op": "test"}],
+            "summary": {"total_entries": 1, "last_entry": "now", "next_id": 2},
+        }
+        save_log(log_file, log_data)
+        result = json.loads(log_file.read_text(encoding="utf-8"))
+        assert result == log_data
+
+    def test_creates_parent_directories(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import save_log
+
+        log_file = tmp_path / "a" / "b" / "log.json"
+        save_log(log_file, {"entries": [], "summary": {}})
+        assert log_file.exists()
+
+    def test_creates_lock_file(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import save_log
+
+        log_file = tmp_path / "log.json"
+        save_log(log_file, {"entries": []})
+        lock_file = tmp_path / "log.lock"
+        assert lock_file.exists()
+
+    def test_overwrites_existing_log(self, tmp_path):
+        from aipass.backup.apps.handlers.json.drive_sync_json import save_log
+
+        log_file = tmp_path / "log.json"
+        save_log(log_file, {"entries": [{"id": 1}], "summary": {"next_id": 2}})
+        save_log(log_file, {"entries": [{"id": 1}, {"id": 2}], "summary": {"next_id": 3}})
+        result = json.loads(log_file.read_text(encoding="utf-8"))
+        assert len(result["entries"]) == 2
+        assert result["summary"]["next_id"] == 3

--- a/src/aipass/backup/tests/test_google_drive_sync.py
+++ b/src/aipass/backup/tests/test_google_drive_sync.py
@@ -188,10 +188,10 @@ class TestHandleCommand:
         result = drive_sync_env["handle_command"](args)
         assert result is False
 
-    def test_handle_command_drive_sync_test_alias(self, drive_sync_env):
-        """'drive-sync-test' routes to _run_sync_test."""
+    def test_handle_command_drive_sync_with_test_flag(self, drive_sync_env):
+        """'drive-sync --test' routes to _run_sync_test."""
         mod = drive_sync_env["module"]
-        args = SimpleNamespace(command="drive-sync-test")
+        args = SimpleNamespace(command="drive-sync", test=True)
 
         with patch.object(mod, "_run_sync_test", return_value=True) as mock_fn:
             result = drive_sync_env["handle_command"](args)

--- a/src/aipass/backup/tests/test_json_handler.py
+++ b/src/aipass/backup/tests/test_json_handler.py
@@ -518,6 +518,151 @@ class TestErrorContracts:
             jh.save_json("t", "config", {"wrong": True})
 
 
+class TestIncrementCounter:
+    """increment_counter increments (or initialises) a named counter in data JSON."""
+
+    def test_increment_new_counter(self, tmp_path, monkeypatch):
+        """Creates counter at 1 when it does not exist yet."""
+        import aipass.backup.apps.handlers.json.json_handler as jh
+
+        json_dir = tmp_path / "backup_json"
+        monkeypatch.setattr(jh, "BACKUP_JSON_DIR", json_dir)
+
+        result = jh.increment_counter("ctr_mod", "my_counter")
+
+        assert result is True
+        data = jh.load_json("ctr_mod", "data")
+        assert data is not None
+        assert data["my_counter"] == 1
+
+    def test_increment_existing_counter(self, tmp_path, monkeypatch):
+        """Adds to an existing counter value."""
+        import json
+        import aipass.backup.apps.handlers.json.json_handler as jh
+
+        json_dir = tmp_path / "backup_json"
+        json_dir.mkdir(parents=True)
+        monkeypatch.setattr(jh, "BACKUP_JSON_DIR", json_dir)
+
+        seed_data = {"created": "2026-01-01", "last_updated": "2026-01-01", "hits": 5}
+        with open(json_dir / "ctr_mod_data.json", "w", encoding="utf-8") as f:
+            json.dump(seed_data, f)
+
+        result = jh.increment_counter("ctr_mod", "hits", amount=3)
+
+        assert result is True
+        data = jh.load_json("ctr_mod", "data")
+        assert data is not None
+        assert data["hits"] == 8
+
+    def test_increment_default_amount_is_one(self, tmp_path, monkeypatch):
+        """Default increment amount is 1."""
+        import aipass.backup.apps.handlers.json.json_handler as jh
+
+        json_dir = tmp_path / "backup_json"
+        monkeypatch.setattr(jh, "BACKUP_JSON_DIR", json_dir)
+
+        jh.increment_counter("def_mod", "count")
+        jh.increment_counter("def_mod", "count")
+
+        data = jh.load_json("def_mod", "data")
+        assert data is not None
+        assert data["count"] == 2
+
+    def test_increment_returns_bool(self, tmp_path, monkeypatch):
+        """Return type is exactly bool."""
+        import aipass.backup.apps.handlers.json.json_handler as jh
+
+        json_dir = tmp_path / "backup_json"
+        monkeypatch.setattr(jh, "BACKUP_JSON_DIR", json_dir)
+
+        result = jh.increment_counter("bool_mod", "x")
+        assert type(result) is bool
+
+
+class TestUpdateDataMetrics:
+    """update_data_metrics merges keyword arguments into the data JSON."""
+
+    def test_update_single_metric(self, tmp_path, monkeypatch):
+        """Sets a single metric key in data."""
+        import aipass.backup.apps.handlers.json.json_handler as jh
+
+        json_dir = tmp_path / "backup_json"
+        monkeypatch.setattr(jh, "BACKUP_JSON_DIR", json_dir)
+
+        result = jh.update_data_metrics("met_mod", status="healthy")
+
+        assert result is True
+        data = jh.load_json("met_mod", "data")
+        assert data is not None
+        assert data["status"] == "healthy"
+
+    def test_update_multiple_metrics(self, tmp_path, monkeypatch):
+        """Sets multiple metric keys in one call."""
+        import aipass.backup.apps.handlers.json.json_handler as jh
+
+        json_dir = tmp_path / "backup_json"
+        monkeypatch.setattr(jh, "BACKUP_JSON_DIR", json_dir)
+
+        result = jh.update_data_metrics("mm_mod", alpha=1, beta="two", gamma=[3])
+
+        assert result is True
+        data = jh.load_json("mm_mod", "data")
+        assert data is not None
+        assert data["alpha"] == 1
+        assert data["beta"] == "two"
+        assert data["gamma"] == [3]
+
+    def test_update_overwrites_existing_key(self, tmp_path, monkeypatch):
+        """Overwrites a pre-existing key with the new value."""
+        import json
+        import aipass.backup.apps.handlers.json.json_handler as jh
+
+        json_dir = tmp_path / "backup_json"
+        json_dir.mkdir(parents=True)
+        monkeypatch.setattr(jh, "BACKUP_JSON_DIR", json_dir)
+
+        seed = {"created": "2026-01-01", "last_updated": "2026-01-01", "level": "low"}
+        with open(json_dir / "ow_mod_data.json", "w", encoding="utf-8") as f:
+            json.dump(seed, f)
+
+        jh.update_data_metrics("ow_mod", level="high")
+
+        data = jh.load_json("ow_mod", "data")
+        assert data is not None
+        assert data["level"] == "high"
+
+    def test_update_preserves_existing_keys(self, tmp_path, monkeypatch):
+        """Keys not mentioned in metrics are left untouched."""
+        import json
+        import aipass.backup.apps.handlers.json.json_handler as jh
+
+        json_dir = tmp_path / "backup_json"
+        json_dir.mkdir(parents=True)
+        monkeypatch.setattr(jh, "BACKUP_JSON_DIR", json_dir)
+
+        seed = {"created": "2026-01-01", "last_updated": "2026-01-01", "keep_me": 42}
+        with open(json_dir / "pk_mod_data.json", "w", encoding="utf-8") as f:
+            json.dump(seed, f)
+
+        jh.update_data_metrics("pk_mod", new_key="added")
+
+        data = jh.load_json("pk_mod", "data")
+        assert data is not None
+        assert data["keep_me"] == 42
+        assert data["new_key"] == "added"
+
+    def test_update_returns_bool(self, tmp_path, monkeypatch):
+        """Return type is exactly bool."""
+        import aipass.backup.apps.handlers.json.json_handler as jh
+
+        json_dir = tmp_path / "backup_json"
+        monkeypatch.setattr(jh, "BACKUP_JSON_DIR", json_dir)
+
+        result = jh.update_data_metrics("br_mod", k="v")
+        assert type(result) is bool
+
+
 class TestEnsureModuleJsonsContract:
     """ensure_module_jsons creates exactly 3 files."""
 

--- a/src/aipass/backup/tests/test_report_formatter.py
+++ b/src/aipass/backup/tests/test_report_formatter.py
@@ -1,0 +1,239 @@
+"""Tests for report_formatter — backup result formatting and display."""
+
+import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _make_result(
+    *,
+    files_checked: int = 10,
+    files_copied: int = 5,
+    files_added: int = 0,
+    files_skipped: int = 3,
+    files_deleted: int = 0,
+    errors: int = 0,
+    error_details: list[str] | None = None,
+    warnings: list[str] | None = None,
+    critical_errors: list[str] | None = None,
+    mode: str = "snapshot",
+) -> MagicMock:
+    """Build a MagicMock that looks like a BackupResult."""
+    result = MagicMock()
+    result.files_checked = files_checked
+    result.files_copied = files_copied
+    result.files_added = files_added
+    result.files_skipped = files_skipped
+    result.files_deleted = files_deleted
+    result.errors = errors
+    result.error_details = error_details or []
+    result.warnings = warnings or []
+    result.critical_errors = critical_errors or []
+    result.mode = mode
+    result.start_time = datetime.datetime.now()
+    return result
+
+
+def _make_mode_config(name: str = "Snapshot") -> dict:
+    return {"name": name}
+
+
+def _noop_filter(skipped: dict) -> dict:
+    return {"directories": [], "files": []}
+
+
+class TestDisplayBackupResults:
+    """display_backup_results logs results without raising."""
+
+    def test_successful_backup_logs_ok(self):
+        """Successful backup with no errors or warnings logs OK status."""
+        from aipass.backup.apps.handlers.reporting.report_formatter import (
+            display_backup_results,
+        )
+
+        result = _make_result()
+        mode_config = _make_mode_config()
+        skipped: dict[str, list[str]] = {"directories": [], "files": []}
+
+        with patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.json_handler"
+        ) as mock_jh:
+            mock_jh.log_operation = MagicMock()
+            display_backup_results(
+                result, mode_config, Path("/tmp/backup"), skipped, _noop_filter
+            )
+
+        mock_jh.log_operation.assert_called_once_with("report_formatted")
+
+    def test_critical_errors_show_failed_status(self):
+        """Backup with critical errors triggers FAILED status path."""
+        from aipass.backup.apps.handlers.reporting.report_formatter import (
+            display_backup_results,
+        )
+
+        result = _make_result(
+            errors=1,
+            critical_errors=["disk full"],
+        )
+        skipped: dict[str, list[str]] = {"directories": [], "files": []}
+
+        with patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.json_handler"
+        ) as mock_jh, patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.logger"
+        ) as mock_logger:
+            mock_jh.log_operation = MagicMock()
+            display_backup_results(
+                result, _make_mode_config(), Path("/tmp/b"), skipped, _noop_filter
+            )
+
+        # Should have logged at least one error call with the critical error text
+        error_calls = [str(c) for c in mock_logger.error.call_args_list]
+        assert any("disk full" in c for c in error_calls)
+
+    def test_non_critical_errors_show_completed_with_errors(self):
+        """Non-critical errors trigger COMPLETED WITH ERRORS path."""
+        from aipass.backup.apps.handlers.reporting.report_formatter import (
+            display_backup_results,
+        )
+
+        result = _make_result(
+            errors=2,
+            error_details=["perm denied on a.txt", "perm denied on b.txt"],
+        )
+        skipped: dict[str, list[str]] = {"directories": [], "files": []}
+
+        with patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.json_handler"
+        ) as mock_jh, patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.logger"
+        ) as mock_logger:
+            mock_jh.log_operation = MagicMock()
+            display_backup_results(
+                result, _make_mode_config(), Path("/tmp/b"), skipped, _noop_filter
+            )
+
+        info_texts = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("COMPLETED WITH ERRORS" in t for t in info_texts)
+
+    def test_warnings_path(self):
+        """Warnings without errors trigger COMPLETED WITH WARNINGS."""
+        from aipass.backup.apps.handlers.reporting.report_formatter import (
+            display_backup_results,
+        )
+
+        result = _make_result(warnings=["symlink skipped"])
+        skipped: dict[str, list[str]] = {"directories": [], "files": []}
+
+        with patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.json_handler"
+        ) as mock_jh, patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.logger"
+        ) as mock_logger:
+            mock_jh.log_operation = MagicMock()
+            display_backup_results(
+                result, _make_mode_config(), Path("/tmp/b"), skipped, _noop_filter
+            )
+
+        info_texts = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("COMPLETED WITH WARNINGS" in t for t in info_texts)
+
+    def test_dry_run_uses_would_language(self):
+        """Dry-run mode uses 'Would copy' phrasing."""
+        from aipass.backup.apps.handlers.reporting.report_formatter import (
+            display_backup_results,
+        )
+
+        result = _make_result()
+        skipped: dict[str, list[str]] = {"directories": [], "files": []}
+
+        with patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.json_handler"
+        ) as mock_jh, patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.logger"
+        ) as mock_logger:
+            mock_jh.log_operation = MagicMock()
+            display_backup_results(
+                result,
+                _make_mode_config(),
+                Path("/tmp/b"),
+                skipped,
+                _noop_filter,
+                dry_run=True,
+            )
+
+        info_texts = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("Would copy" in t for t in info_texts)
+
+    def test_tracked_skipped_items_displayed(self):
+        """When filter returns tracked items, they appear in the log."""
+        from aipass.backup.apps.handlers.reporting.report_formatter import (
+            display_backup_results,
+        )
+
+        result = _make_result()
+        skipped: dict[str, list[str]] = {
+            "directories": [".git"],
+            "files": ["secret.env"],
+        }
+
+        def filter_fn(items: dict) -> dict:
+            return {"directories": [".git"], "files": ["secret.env"]}
+
+        with patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.json_handler"
+        ) as mock_jh, patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.logger"
+        ) as mock_logger:
+            mock_jh.log_operation = MagicMock()
+            display_backup_results(
+                result, _make_mode_config(), Path("/tmp/b"), skipped, filter_fn
+            )
+
+        info_texts = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("NOTABLE SKIPPED" in t for t in info_texts)
+
+    def test_no_skipped_items_message(self):
+        """When nothing is skipped, logs 'No items were skipped.'."""
+        from aipass.backup.apps.handlers.reporting.report_formatter import (
+            display_backup_results,
+        )
+
+        result = _make_result()
+        skipped: dict[str, list[str]] = {"directories": [], "files": []}
+
+        with patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.json_handler"
+        ) as mock_jh, patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.logger"
+        ) as mock_logger:
+            mock_jh.log_operation = MagicMock()
+            display_backup_results(
+                result, _make_mode_config(), Path("/tmp/b"), skipped, _noop_filter
+            )
+
+        info_texts = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("No items were skipped" in t for t in info_texts)
+
+    def test_error_details_capped_at_ten(self):
+        """Only first 10 error details are logged, rest summarised."""
+        from aipass.backup.apps.handlers.reporting.report_formatter import (
+            display_backup_results,
+        )
+
+        details = [f"error {i}" for i in range(15)]
+        result = _make_result(errors=15, error_details=details)
+        skipped: dict[str, list[str]] = {"directories": [], "files": []}
+
+        with patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.json_handler"
+        ) as mock_jh, patch(
+            "aipass.backup.apps.handlers.reporting.report_formatter.logger"
+        ) as mock_logger:
+            mock_jh.log_operation = MagicMock()
+            display_backup_results(
+                result, _make_mode_config(), Path("/tmp/b"), skipped, _noop_filter
+            )
+
+        info_texts = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("5 more errors" in t for t in info_texts)

--- a/src/aipass/backup/tests/test_statistics_handler.py
+++ b/src/aipass/backup/tests/test_statistics_handler.py
@@ -1,0 +1,202 @@
+"""Tests for statistics_handler — backup statistics tracking."""
+
+from unittest.mock import MagicMock
+
+
+def _empty_data() -> dict:
+    """Return a minimal valid data structure matching what load_json would return."""
+    return {
+        "last_updated": "2026-01-01T00:00:00",
+        "runtime_state": {},
+        "statistics": {
+            "total_backups": 0,
+            "successful_backups": 0,
+            "failed_backups": 0,
+            "snapshot_backups": 0,
+            "versioned_backups": 0,
+            "total_files_processed": 0,
+        },
+        "recent_backups": [],
+    }
+
+
+class TestUpdateDataFile:
+    """update_data_file persists backup statistics via load_json / save_json."""
+
+    def test_updates_runtime_state_on_success(self, monkeypatch):
+        """Runtime state reflects a successful backup."""
+        import aipass.backup.apps.handlers.json.statistics_handler as sh
+
+        result = MagicMock()
+        result.success = True
+        result.mode = "snapshot"
+        result.files_copied = 12
+        result.files_checked = 20
+        result.errors = 0
+
+        captured: dict = {}
+
+        def fake_save(_module: str, _json_type: str, data: dict) -> bool:
+            captured.update(data)
+            return True
+
+        monkeypatch.setattr(sh, "load_json", lambda *_a, **_kw: _empty_data())
+        monkeypatch.setattr(sh, "save_json", fake_save)
+
+        sh.update_data_file(result)
+
+        assert captured["runtime_state"]["current_status"] == "completed"
+        assert captured["runtime_state"]["active_mode"] == "snapshot"
+        assert captured["runtime_state"]["total_files_backed_up"] == 12
+        assert captured["runtime_state"]["backup_in_progress"] is False
+
+    def test_updates_runtime_state_on_failure(self, monkeypatch):
+        """Runtime state reflects a failed backup."""
+        import aipass.backup.apps.handlers.json.statistics_handler as sh
+
+        result = MagicMock()
+        result.success = False
+        result.mode = "versioned"
+        result.files_copied = 0
+        result.files_checked = 5
+        result.errors = 3
+
+        captured: dict = {}
+
+        def fake_save(_module: str, _json_type: str, data: dict) -> bool:
+            captured.update(data)
+            return True
+
+        monkeypatch.setattr(sh, "load_json", lambda *_a, **_kw: _empty_data())
+        monkeypatch.setattr(sh, "save_json", fake_save)
+
+        sh.update_data_file(result)
+
+        assert captured["runtime_state"]["current_status"] == "failed"
+        assert captured["statistics"]["failed_backups"] == 1
+        assert captured["statistics"]["successful_backups"] == 0
+
+    def test_increments_statistics_counters(self, monkeypatch):
+        """Total, successful, and mode-specific counters increment correctly."""
+        import aipass.backup.apps.handlers.json.statistics_handler as sh
+
+        result = MagicMock()
+        result.success = True
+        result.mode = "versioned"
+        result.files_copied = 3
+        result.files_checked = 10
+        result.errors = 0
+
+        existing_data = {
+            "last_updated": "2026-01-01",
+            "runtime_state": {},
+            "statistics": {
+                "total_backups": 5,
+                "successful_backups": 4,
+                "failed_backups": 1,
+                "snapshot_backups": 3,
+                "versioned_backups": 2,
+                "total_files_processed": 100,
+            },
+            "recent_backups": [],
+        }
+
+        captured: dict = {}
+
+        def fake_save(_module: str, _json_type: str, data: dict) -> bool:
+            captured.update(data)
+            return True
+
+        monkeypatch.setattr(sh, "load_json", lambda *_a, **_kw: existing_data)
+        monkeypatch.setattr(sh, "save_json", fake_save)
+
+        sh.update_data_file(result)
+
+        assert captured["statistics"]["total_backups"] == 6
+        assert captured["statistics"]["successful_backups"] == 5
+        assert captured["statistics"]["versioned_backups"] == 3
+        assert captured["statistics"]["total_files_processed"] == 110
+
+    def test_snapshot_mode_counter(self, monkeypatch):
+        """Snapshot mode increments snapshot_backups counter."""
+        import aipass.backup.apps.handlers.json.statistics_handler as sh
+
+        result = MagicMock()
+        result.success = True
+        result.mode = "snapshot"
+        result.files_copied = 1
+        result.files_checked = 1
+        result.errors = 0
+
+        captured: dict = {}
+
+        def fake_save(_module: str, _json_type: str, data: dict) -> bool:
+            captured.update(data)
+            return True
+
+        monkeypatch.setattr(sh, "load_json", lambda *_a, **_kw: _empty_data())
+        monkeypatch.setattr(sh, "save_json", fake_save)
+
+        sh.update_data_file(result)
+
+        assert captured["statistics"]["snapshot_backups"] == 1
+        assert captured["statistics"]["versioned_backups"] == 0
+
+    def test_recent_backups_capped_at_ten(self, monkeypatch):
+        """Recent backups list never exceeds 10 entries."""
+        import aipass.backup.apps.handlers.json.statistics_handler as sh
+
+        result = MagicMock()
+        result.success = True
+        result.mode = "snapshot"
+        result.files_copied = 1
+        result.files_checked = 1
+        result.errors = 0
+
+        existing_data = {
+            "last_updated": "2026-01-01",
+            "runtime_state": {},
+            "statistics": {
+                "total_backups": 10,
+                "successful_backups": 10,
+                "failed_backups": 0,
+                "snapshot_backups": 10,
+                "versioned_backups": 0,
+                "total_files_processed": 50,
+            },
+            "recent_backups": [{"idx": i} for i in range(10)],
+        }
+
+        captured: dict = {}
+
+        def fake_save(_module: str, _json_type: str, data: dict) -> bool:
+            captured.update(data)
+            return True
+
+        monkeypatch.setattr(sh, "load_json", lambda *_a, **_kw: existing_data)
+        monkeypatch.setattr(sh, "save_json", fake_save)
+
+        sh.update_data_file(result)
+
+        assert len(captured["recent_backups"]) == 10
+
+    def test_handles_exception_gracefully(self, monkeypatch):
+        """Does not raise when load_json throws; logs the error instead."""
+        import aipass.backup.apps.handlers.json.statistics_handler as sh
+
+        result = MagicMock()
+        result.success = True
+        result.mode = "snapshot"
+        result.files_copied = 0
+        result.files_checked = 0
+        result.errors = 0
+
+        mock_print = MagicMock()
+        monkeypatch.setattr(sh, "load_json", MagicMock(side_effect=RuntimeError("boom")))
+        monkeypatch.setattr(sh, "safe_print", mock_print)
+
+        # Should not raise
+        sh.update_data_file(result)
+
+        mock_print.assert_called_once()
+        assert "boom" in mock_print.call_args[0][0]

--- a/src/aipass/drone/README.md
+++ b/src/aipass/drone/README.md
@@ -122,14 +122,14 @@ Commands in the interactive tuple bypass capture and inherit the terminal direct
 | Command      | Reason                                      |
 |--------------|---------------------------------------------|
 | `monitor`    | Prax real-time monitoring (live TUI)        |
-| `snapshot`   | Backup snapshot (Rich progress bars)        |
-| `versioned`  | Backup versioned (Rich progress, long-running) |
+| `audit`      | Seedgo audit (Rich progress bars)           |
 
 **Per-branch allowlist** — all commands from these branches get interactive mode:
 
-| Branch | Reason                                      |
-|--------|---------------------------------------------|
-| `cli`  | User-facing CLI with Rich formatted output  |
+| Branch   | Reason                                        |
+|----------|-----------------------------------------------|
+| `cli`    | User-facing CLI with Rich formatted output    |
+| `backup` | Heavy-IO branch (file scanning, Google APIs)  |
 
 To add: edit `interactive_commands` or `interactive_branches` in `_handle_target()` in `apps/drone.py`.
 

--- a/src/aipass/drone/apps/drone.py
+++ b/src/aipass/drone/apps/drone.py
@@ -269,8 +269,8 @@ def _handle_custom_command(args: list[str]) -> int:
     module_name = target.lstrip("@").lower()
 
     # Interactive detection -- same logic as _handle_target
-    interactive_commands = ("monitor", "snapshot", "versioned", "audit")
-    interactive_branches = ("cli",)
+    interactive_commands = ("monitor", "audit")
+    interactive_branches = ("cli", "backup")
     interactive = command in interactive_commands or module_name in interactive_branches
 
     try:
@@ -300,8 +300,8 @@ def _handle_target(args: List[str]) -> int:
     # Interactive mode bypasses capture + timeout for human-facing output.
     # Per-command: specific commands that need live terminal (progress bars, TUI).
     # Per-branch: all commands from that branch get interactive mode (Rich CLI).
-    interactive_commands = ("monitor", "snapshot", "versioned", "audit")
-    interactive_branches = ("cli",)
+    interactive_commands = ("monitor", "audit")
+    interactive_branches = ("cli", "backup")
     first_cmd = rest[0] if rest and rest[0] != "--help" else None
     needs_interactive = (
         first_cmd in interactive_commands or module_name in interactive_branches


### PR DESCRIPTION
## Summary
- **Backup 4-phase overnight rebuild** (FPLAN-0141): branding cleanup, JSON atomic writes (fixes corruption), Google Drive auth migrated to @api, 75 new tests (182→257), drive-sync bugs fixed
- **Drone**: backup promoted to `interactive_branches` — all backup commands get terminal pass-through, no timeout
- **README**: UNDER CONSTRUCTION tag added

## Changes
- **Atomic writes**: json_handler, changelog_handler, backup_info_handler, backup_timestamps all use temp file + `os.replace()` — prevents JSON corruption on interrupted writes
- **Google Drive migration**: `drive_sync_client.py` now imports from `aipass.api.apps.modules.google_client` — removed 80-line auth, thread service, retry logic (all from API now)
- **Drive-sync fixes**: list index mismatch (legacy JSON format auto-migration), drive-test routing bug, config stuck disabled
- **New test files**: test_diff_generator, test_drive_sync_json, test_report_formatter, test_statistics_handler, test_backup_metadata_builder
- **Drone**: `interactive_branches` tuple includes backup — all commands bypass 30s timeout

## Test plan
- [x] `python -m pytest src/aipass/backup/tests/ -v` — 257 passed
- [x] `drone @seedgo audit aipass @backup` — 99% (33/33 standards)
- [x] `drone @backup snapshot --dry-run` — 2691 files, completes clean
- [x] `drone @backup versioned --dry-run` — 2691 files, completes clean
- [x] `drone @backup all` — full pipeline (snapshot→versioned→drive-sync) completes
- [x] `drone @backup drive-sync --test` — 4 files uploaded to Google Drive
- [x] `drone @seedgo audit aipass @drone` — 100% (393 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)