### PR TITLE
feat(security): Add gitleaks secret scanning to prevent API key leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ build/-
 # Secrets
 .env
 
+# API branch (private infrastructure — contains key handling code)
+src/aipass/api/
+
 # Plans (managed by flow, local to each installation)
 FPLAN-*.md
 DPLAN-*.md

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,67 @@
+# Gitleaks configuration for AIPass
+# Prevents API keys and secrets from being committed to the repo.
+#
+# Usage: gitleaks runs automatically via pre-commit hook.
+# Manual scan: gitleaks detect --config .gitleaks.toml
+
+title = "AIPass Secret Detection Rules"
+
+[extend]
+useDefault = true
+
+# --- Custom rules for AIPass-specific key formats ---
+
+[[rules]]
+id = "openrouter-api-key"
+description = "OpenRouter API key (sk-or-v1- prefix with 20+ alphanumeric chars)"
+regex = '''sk-or-v1-[a-zA-Z0-9]{20,}'''
+keywords = ["sk-or-v1-"]
+
+[[rules]]
+id = "openai-api-key"
+description = "OpenAI API key (sk- prefix with 20+ chars, not sk-or/sk-ant)"
+regex = '''sk-(?!or|ant)[a-zA-Z0-9]{20,}'''
+keywords = ["sk-"]
+
+[[rules]]
+id = "anthropic-api-key"
+description = "Anthropic API key (sk-ant- prefix)"
+regex = '''sk-ant-[a-zA-Z0-9]{20,}'''
+keywords = ["sk-ant-"]
+
+[[rules]]
+id = "google-api-key"
+description = "Google API key (AIza prefix)"
+regex = '''AIza[0-9A-Za-z\-_]{35,}'''
+keywords = ["AIza"]
+
+[[rules]]
+id = "bearer-token-in-code"
+description = "Bearer token hardcoded in source (not in test assertions)"
+regex = '''Bearer\s+[a-zA-Z0-9_\-\.]{40,}'''
+keywords = ["Bearer"]
+
+[[rules]]
+id = "env-file-key-assignment"
+description = "API key assigned in code with realistic value"
+regex = '''(?:OPENROUTER|OPENAI|ANTHROPIC|GOOGLE)_API_KEY\s*=\s*["']?(?:sk-|AIza)[a-zA-Z0-9\-_]{20,}'''
+keywords = ["API_KEY"]
+
+# --- Allowlists ---
+
+[allowlist]
+# Files that are allowed to contain key-like patterns
+paths = [
+    '''\.gitleaks\.toml$''',
+    '''\.pre-commit-config\.yaml$''',
+]
+
+# Strings that are explicitly allowed (FAKE/NOTREAL test keys, prefix patterns)
+regexes = [
+    '''FAKE-''',
+    '''NOTREAL''',
+    '''your-key-here''',
+    '''your-openai-key-here''',
+    '''sk-or-v1-short''',
+    '''sk-wrong-prefix''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# Pre-commit hooks for AIPass
+# Install: pip install pre-commit && pre-commit install
+# Manual run: pre-commit run --all-files
+
+repos:
+  # Gitleaks — secret detection
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## Summary
- Adds `.gitleaks.toml` with custom secret detection rules for OpenRouter (`sk-or-v1-`), OpenAI (`sk-`), Anthropic (`sk-ant-`), Google (`AIza`), and Bearer tokens
- Adds `.pre-commit-config.yaml` wiring gitleaks as a pre-commit hook (`pip install pre-commit && pre-commit install`)
- Allowlists `FAKE-` and `NOTREAL` prefixed test keys so tests don't trigger false positives

### Also done locally (api/ is gitignored):
- Audited all test files in `src/aipass/api/tests/` — replaced 30+ realistic hex-pattern keys with `FAKE-`/`NOTREAL` conventions
- Created `api/docs/SECURITY.md` documenting key management architecture, test key conventions, and incident response

### Root cause
Test files used `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` which was indistinguishable from a real key. A real key got mixed in and leaked to the public repo. OpenRouter auto-disabled it.

### Defense layers now in place
1. `.gitignore` — blocks `.env`, credential files, api/ branch
2. Pre-commit hook — catches key patterns before they enter local history
3. Gitleaks (this PR) — automated scanning with custom rules and allowlists
4. GitHub Push Protection — server-side scanning (enabled by default on public repos)

## Test plan
- [x] 290/290 API tests pass after key pattern changes
- [ ] `pip install pre-commit && pre-commit install` to activate gitleaks hook
- [ ] Verify gitleaks catches a test commit with a realistic key pattern
- [ ] Verify gitleaks allows commits with FAKE-/NOTREAL prefixed keys


🤖 Generated with [Claude Code](https://claude.com/claude-code)