### PR TITLE
fix(seedgo): __init__.py false positives in imports + naming

### DIFF
--- a/src/aipass/seedgo/apps/handlers/aipass_standards/imports_check.py
+++ b/src/aipass/seedgo/apps/handlers/aipass_standards/imports_check.py
@@ -57,6 +57,15 @@ def check_module(module_path: str, bypass_rules: list | None = None) -> Dict:
     checks = []
     path = Path(module_path)
 
+    # Python package marker — no imports required by convention
+    if path.name == '__init__.py':
+        return {
+            'passed': True,
+            'checks': [{'name': 'Package marker', 'passed': True, 'message': '__init__.py — Python package marker, no import checks'}],
+            'score': 100,
+            'standard': 'IMPORTS'
+        }
+
     if is_bypassed(module_path, 'imports', bypass_rules=bypass_rules):
         return {
             'passed': True,

--- a/src/aipass/seedgo/apps/handlers/aipass_standards/naming_check.py
+++ b/src/aipass/seedgo/apps/handlers/aipass_standards/naming_check.py
@@ -146,6 +146,14 @@ def check_file_naming(module_path: str, path: Path) -> Dict:
     """
     filename = path.stem  # filename without extension
 
+    # Python-reserved package marker — cannot be renamed
+    if path.name == '__init__.py':
+        return {
+            'name': 'File naming',
+            'passed': True,
+            'message': '__init__.py (Python-reserved package marker)'
+        }
+
     # Check if it's the documented exception
     if filename == 'json_handler' and '/handlers/json/' in module_path:
         return {


### PR DESCRIPTION
## Summary
- **imports checker**: empty `__init__.py` produced zero checks → score 0 → `Failed (no details)`. Now short-circuits to PASS.
- **naming checker**: `__init__` fails the `^[a-z]...` snake_case regex since it starts with `_`. Now short-circuits to PASS (Python-reserved filename).

Reported by @devpulse while adding `navigator/__init__.py` to compass during DPLAN-0128.

## Reproduction (before fix)
```
drone @seedgo checklist <empty-__init__.py>
  ✗ imports: Failed (no details)
  ✗ naming: __init__.py uses invalid characters (use snake_case: lowercase + underscores)
```

## Verification (after fix)
- Target file now shows `✓ imports` and `✓ naming`
- Non-`__init__.py` files still run the full checks (verified on `seedgo.py`)
- Full self-audit still **99%** (32/33 standards at 100%, Architecture 99% unchanged)

## Test plan
- [x] Reproduce both failures on empty `__init__.py`
- [x] Apply short-circuit in both checkers
- [x] Verify `__init__.py` now passes both
- [x] Verify regular `.py` files still get checked
- [x] Full self-audit regression (99%, no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)