### PR TITLE
feat(drone): fix merge_plugin: worktree branch-cleanup failure treated as non-fatal warning

### DIFF
--- a/src/aipass/drone/apps/plugins/devpulse_ops/merge_plugin.py
+++ b/src/aipass/drone/apps/plugins/devpulse_ops/merge_plugin.py
@@ -49,9 +49,21 @@ def merge_pr(pr_number: str, caller: str) -> dict:
             capture_output=True, text=True, cwd=str(repo_root),
         )
         if merge.returncode != 0:
-            result["message"] = f"Merge failed: {merge.stderr.strip()}"
-            logger.error(result["message"])
-            return result
+            merge_stderr = merge.stderr.strip()
+            # gh pr merge --delete-branch fails with non-zero if the local branch
+            # can't be deleted (e.g. checked out in a worktree). The GitHub-side
+            # merge + remote branch deletion already completed — only local
+            # cleanup failed. Treat this as a warning and continue.
+            if "cannot delete branch" in merge_stderr and "worktree" in merge_stderr:
+                logger.warning(
+                    "merge_pr: PR #%s merged but local branch cleanup skipped "
+                    "(branch in use by worktree): %s",
+                    pr_number, merge_stderr,
+                )
+            else:
+                result["message"] = f"Merge failed: {merge_stderr}"
+                logger.error(result["message"])
+                return result
 
         # Step 2: Sync local main
         pull = subprocess.run(


### PR DESCRIPTION
## Summary

- Detect worktree branch-cleanup failure from `gh pr merge --delete-branch` and treat it as a non-fatal warning
- `gh pr merge --delete-branch` returns non-zero if the local branch can't be deleted (e.g. checked out in a Claude Code worktree), even though the GitHub-side merge + remote branch deletion already completed
- Root cause of ERROR 02a438a6: merge of fix/wake-cross-project-resolve failed at local cleanup step only — the PR was actually merged successfully

## Branch

Created by @drone via `drone @git pr`
