### PR TITLE
feat(system): fix(windows): PYTHONUTF8=1 in drone cli.py for Rich Unicode on Windows (#296) + STATUS.md reset to stub (#291) + README.md platform honesty (Linux tested, macOS untested, Windows in progress)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ For detailed session history, see [HERALD.md](HERALD.md).
 - At least one AI CLI: Claude Code (recommended), Codex, or Gemini CLI
 - `sudo` access (for global CLI symlinks)
 - API keys optional (OpenRouter/OpenAI — for optional add-on agents)
-- **Platforms:** Linux (fully tested), macOS (untested, should work), Windows via WSL2
+- **Platforms:** Linux (tested, primary dev environment), macOS (untested), Windows (native testing in progress — see [open issues](https://github.com/AIOSAI/AIPass/issues?q=is%3Aissue+is%3Aopen+Windows))
 
 ---
 

--- a/src/aipass/drone/cli.py
+++ b/src/aipass/drone/cli.py
@@ -13,7 +13,14 @@ Usage:
   drone @module command [args]   Route command to internal module
 """
 
+import os
 import sys
+
+# Windows terminals default to cp1252 which can't encode Rich's Unicode
+# characters (box-drawing, em dashes, arrows). Force UTF-8 before any
+# imports that trigger Rich output.
+if sys.platform == "win32":
+    os.environ.setdefault("PYTHONUTF8", "1")
 
 from aipass.drone.apps.drone import main as _drone_main
 


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- fix(windows): PYTHONUTF8=1 in drone cli.py for Rich Unicode on Windows (#296) + STATUS.md reset to stub (#291) + README.md platform honesty (Linux tested, macOS untested, Windows in progress)
- 1 commit(s) ahead of origin/main
