### PR TITLE
feat(system): ci: add Windows setup test workflow — runs setup.sh + drone CLI verification on windows-latest GitHub Actions runner. Triggers on changes to setup.sh, handler __init__.py files, cli.py, or pyproject.toml. Closes the 'we never tested on Windows' gap.

### DIFF
--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -1,0 +1,38 @@
+name: Windows Setup Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'setup.sh'
+      - 'src/aipass/*/apps/handlers/__init__.py'
+      - 'src/aipass/drone/cli.py'
+      - 'pyproject.toml'
+  pull_request:
+    paths:
+      - 'setup.sh'
+      - 'src/aipass/*/apps/handlers/__init__.py'
+      - 'src/aipass/drone/cli.py'
+      - 'pyproject.toml'
+
+jobs:
+  windows-setup:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run setup.sh
+        shell: bash
+        run: bash setup.sh
+
+      - name: Verify drone CLI
+        shell: bash
+        run: |
+          export PYTHONUTF8=1
+          drone --version
+          drone systems
+          drone @seedgo --help


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- ci: add Windows setup test workflow — runs setup.sh + drone CLI verification on windows-latest GitHub Actions runner. Triggers on changes to setup.sh, handler __init__.py files, cli.py, or pyproject.toml. Closes the 'we never tested on Windows' gap.
- 1 commit(s) ahead of origin/main
