### PR TITLE
feat(system): feat: ship /memo and /prep slash commands in .claude/commands/ — available on every clone, no per-user setup needed. Previously only existed in developer's personal ~/.claude/commands/.

### DIFF
--- a/.claude/commands/memo.md
+++ b/.claude/commands/memo.md
@@ -1,0 +1,23 @@
+# Memory Update
+
+Purpose: Update branch memory files after completing work this session.
+
+## Execution
+
+1. Read `.trinity/passport.json` first — re-absorb your identity, role, and principles before writing memories
+2. Review what was done this session (context, recent changes, key decisions)
+3. Update each file below as needed
+4. Confirm completion — list files updated
+
+## Memory Roles
+
+Each memory file plays a distinct role. Update based on what actually changed this session.
+
+- **`.trinity/passport.json`** — IDENTITY. Who you are: role, capabilities, principles. Only update if identity genuinely evolved this session. Don't touch it just to touch it.
+- **`.trinity/local.json`** — YOUR MEMORY. Session history and key_learnings. Add a session entry for significant work. Add key_learnings for facts you'd need next time. Trim oldest sessions if over 20.
+- **`.trinity/observations.json`** — YOUR MEMORY OF THE USER. Collaboration insights, preferences, friction points, flow states. Skip entirely if nothing new about the user this session.
+- **`STATUS.local.md`** — PUBLIC STATUS BEACON. Current work, known issues, todos, notepad. Auto-synced to central STATUS.md on PR events — this is how other branches see you. Keep Current Work accurate and drop quick notes in the Notepad section.
+
+## If Relevant
+
+- **README.md** — Does it reflect current state? Update if stale.

--- a/.claude/commands/prep.md
+++ b/.claude/commands/prep.md
@@ -1,0 +1,55 @@
+# Session Wrap-Up
+
+Purpose: Button up everything at the end of a session — or before a /compact. Memories, plans, git — all tidy. Works for both closing out a chat and preparing for compaction.
+
+**Workflow:** `/prep` → review output → close chat or `/compact`
+
+## Execution
+
+1. Read `.trinity/passport.json` first — re-absorb your identity before writing anything
+2. Do ALL of the following, then confirm what was updated
+
+## 1. Memories
+
+Each memory file plays a distinct role. Update based on what actually changed this session.
+
+- **`.trinity/passport.json`** — IDENTITY. Who you are: role, capabilities, principles. Only update if identity genuinely evolved this session.
+- **`.trinity/local.json`** — YOUR MEMORY. Add/update session entry with a summary of work done. Add key_learnings for anything learned. Trim oldest sessions if over 20.
+- **`.trinity/observations.json`** — YOUR MEMORY OF THE USER. Collaboration insights, preferences, friction points. Skip if nothing new about the user this session.
+- **`STATUS.local.md`** — PUBLIC STATUS BEACON. Current work, known issues, todos, notepad. Auto-synced to central STATUS.md on PR events — this is how other branches see you. Keep Current Work accurate.
+
+## 2. Active Plans
+
+- Check any DPLANs or FPLANs referenced in this session
+- Update their execution logs, status, decision logs with current state
+- If a plan was completed, note it (but don't close — the user does that)
+
+## 3. Git State
+
+- Run `git status` — report uncommitted changes
+- If there's a logical commit waiting, suggest it (don't commit without asking)
+- Note the current branch and any open PRs
+
+## 4. Inbox
+
+- Run `drone @ai_mail inbox 2>/dev/null` — report any unread emails
+- Close any that were already processed but not formally closed
+
+## 5. Loose Ends
+
+- Flag anything in-flight: running background agents, dispatched branches waiting for replies, pending decisions
+- If anything can't survive compaction (e.g., agent IDs needed for resume), write it to STATUS.local.md Notepad
+
+## Confirm
+
+List everything updated. Format:
+```
+Prep complete:
+- local.json: [what was added]
+- observations.json: [updated / skipped]
+- STATUS.local.md: [updated / skipped]
+- Plans: [which ones updated]
+- Git: [branch, uncommitted count, suggestion]
+- Inbox: [count, action taken]
+- Loose ends: [any flagged]
+```


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- feat: ship /memo and /prep slash commands in .claude/commands/ — available on every clone, no per-user setup needed. Previously only existed in developer's personal ~/.claude/commands/.
- 1 commit(s) ahead of origin/main
