### PR TITLE
feat(system): fix(windows-ci): stop swallowing ensurepip errors in setup.sh, add get-pip.py fallback and hard verify

Every Windows CI run since windows-test.yml was created has failed silently on the same line: pip missing after venv creation. Root cause: ensurepip invocation was wrapped with --quiet, 2>/dev/null, and || true — three layers of error-hiding. ensurepip was running, failing silently, and the script continued to pip install which exploded with 'No module named pip'.

Fix removes the error-suppression so real errors surface, adds a get-pip.py fallback if ensurepip whiffs, and hard-verifies pip exists before continuing. If this fix itself fails on CI, we'll see the actual error for the first time.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -85,7 +85,14 @@ if [ "$IS_WINDOWS" -eq 1 ] && [ -f ".venv/Scripts/python.exe" ]; then
     # Bootstrap pip if missing (--without-pip on Windows)
     if ! "$VENV_PYTHON" -m pip --version &>/dev/null 2>&1; then
         echo "Bootstrapping pip in venv ..."
-        "$VENV_PYTHON" -m ensurepip --default-pip --quiet 2>/dev/null || true
+        "$VENV_PYTHON" -m ensurepip --default-pip || true
+        if ! "$VENV_PYTHON" -m pip --version &>/dev/null 2>&1; then
+            echo "ensurepip did not install pip — falling back to get-pip.py"
+            "$VENV_PYTHON" -c "import urllib.request; urllib.request.urlretrieve('https://bootstrap.pypa.io/get-pip.py', 'get-pip.py')"
+            "$VENV_PYTHON" get-pip.py
+            rm -f get-pip.py
+        fi
+        "$VENV_PYTHON" -m pip --version || { echo "ERROR: pip still missing after bootstrap" >&2; exit 1; }
     fi
 else
     source .venv/bin/activate


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- fix(windows-ci): stop swallowing ensurepip errors in setup.sh, add get-pip.py fallback and hard verify

Every Windows CI run since windows-test.yml was created has failed silently on the same line: pip missing after venv creation. Root cause: ensurepip invocation was wrapped with --quiet, 2>/dev/null, and || true — three layers of error-hiding. ensurepip was running, failing silently, and the script continued to pip install which exploded with 'No module named pip'.

Fix removes the error-suppression so real errors surface, adds a get-pip.py fallback if ensurepip whiffs, and hard-verifies pip exists before continuing. If this fix itself fails on CI, we'll see the actual error for the first time.
- 1 commit(s) ahead of origin/main
