### PR TITLE
feat(system): fix(windows-ci): activate venv in Verify step so drone binary is on PATH

PR #330 fixed the pip bootstrap (ensurepip error-swallowing in setup.sh). With that fix working, the Verify step in windows-test.yml now fails at 'drone: command not found' (exit 127). Root cause: each CI step spawns a fresh shell, so the venv activation from setup.sh doesn't carry to Verify. drone lives at .venv/Scripts/drone.exe which isn't on the default PATH.

Fix: prepend 'source .venv/Scripts/activate' to the Verify step so drone is findable.

Stacked on PR #330 conceptually — both fixes needed for windows-test.yml to actually pass.

### DIFF
--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Verify drone CLI
         shell: bash
         run: |
+          source .venv/Scripts/activate
           export PYTHONUTF8=1
           drone --version
           drone systems

--- a/setup.sh
+++ b/setup.sh
@@ -85,7 +85,14 @@ if [ "$IS_WINDOWS" -eq 1 ] && [ -f ".venv/Scripts/python.exe" ]; then
     # Bootstrap pip if missing (--without-pip on Windows)
     if ! "$VENV_PYTHON" -m pip --version &>/dev/null 2>&1; then
         echo "Bootstrapping pip in venv ..."
-        "$VENV_PYTHON" -m ensurepip --default-pip --quiet 2>/dev/null || true
+        "$VENV_PYTHON" -m ensurepip --default-pip || true
+        if ! "$VENV_PYTHON" -m pip --version &>/dev/null 2>&1; then
+            echo "ensurepip did not install pip — falling back to get-pip.py"
+            "$VENV_PYTHON" -c "import urllib.request; urllib.request.urlretrieve('https://bootstrap.pypa.io/get-pip.py', 'get-pip.py')"
+            "$VENV_PYTHON" get-pip.py
+            rm -f get-pip.py
+        fi
+        "$VENV_PYTHON" -m pip --version || { echo "ERROR: pip still missing after bootstrap" >&2; exit 1; }
     fi
 else
     source .venv/bin/activate


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- fix(windows-ci): activate venv in Verify step so drone binary is on PATH

PR #330 fixed the pip bootstrap (ensurepip error-swallowing in setup.sh). With that fix working, the Verify step in windows-test.yml now fails at 'drone: command not found' (exit 127). Root cause: each CI step spawns a fresh shell, so the venv activation from setup.sh doesn't carry to Verify. drone lives at .venv/Scripts/drone.exe which isn't on the default PATH.

Fix: prepend 'source .venv/Scripts/activate' to the Verify step so drone is findable.

Stacked on PR #330 conceptually — both fixes needed for windows-test.yml to actually pass.
- 2 commit(s) ahead of origin/main
