### PR TITLE
feat(system): fix(windows-ci): combine pip bootstrap fix + venv activation in Verify step

Combines both fixes needed to get windows-test.yml actually passing:

1. setup.sh: stop swallowing ensurepip errors (quiet + 2>/dev/null + || true was
   hiding real failures — pip was silently not installed). Add get-pip.py fallback
   and hard pip verification.

2. windows-test.yml: add 'source .venv/Scripts/activate' to Verify step. Each CI
   step gets a fresh shell — setup.sh's venv activation doesn't carry over, so
   drone wasn't on PATH in the subsequent step.

Together, these should take Windows CI from the 'silent failure every run since
creation' state to actually green. Supersedes PRs #330 and #331 which had the
fixes on separate branches (neither green alone).

### DIFF
--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Verify drone CLI
         shell: bash
         run: |
+          source .venv/Scripts/activate
           export PYTHONUTF8=1
           drone --version
           drone systems

--- a/setup.sh
+++ b/setup.sh
@@ -85,7 +85,14 @@ if [ "$IS_WINDOWS" -eq 1 ] && [ -f ".venv/Scripts/python.exe" ]; then
     # Bootstrap pip if missing (--without-pip on Windows)
     if ! "$VENV_PYTHON" -m pip --version &>/dev/null 2>&1; then
         echo "Bootstrapping pip in venv ..."
-        "$VENV_PYTHON" -m ensurepip --default-pip --quiet 2>/dev/null || true
+        "$VENV_PYTHON" -m ensurepip --default-pip || true
+        if ! "$VENV_PYTHON" -m pip --version &>/dev/null 2>&1; then
+            echo "ensurepip did not install pip — falling back to get-pip.py"
+            "$VENV_PYTHON" -c "import urllib.request; urllib.request.urlretrieve('https://bootstrap.pypa.io/get-pip.py', 'get-pip.py')"
+            "$VENV_PYTHON" get-pip.py
+            rm -f get-pip.py
+        fi
+        "$VENV_PYTHON" -m pip --version || { echo "ERROR: pip still missing after bootstrap" >&2; exit 1; }
     fi
 else
     source .venv/bin/activate


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- fix(windows-ci): combine pip bootstrap fix + venv activation in Verify step

Combines both fixes needed to get windows-test.yml actually passing:

1. setup.sh: stop swallowing ensurepip errors (quiet + 2>/dev/null + || true was
   hiding real failures — pip was silently not installed). Add get-pip.py fallback
   and hard pip verification.

2. windows-test.yml: add 'source .venv/Scripts/activate' to Verify step. Each CI
   step gets a fresh shell — setup.sh's venv activation doesn't carry over, so
   drone wasn't on PATH in the subsequent step.

Together, these should take Windows CI from the 'silent failure every run since
creation' state to actually green. Supersedes PRs #330 and #331 which had the
fixes on separate branches (neither green alone).
- 1 commit(s) ahead of origin/main
