### PR TITLE
feat(system): chore(lint)+feat(seedgo): ruff F841+E741 cleanup (36 errors) + ruff_check as seedgo's 33rd standard — combined replacement for #334/#335/#336 invalidated by #333 squash-merge

### DIFF
--- a/src/aipass/ai_mail/tests/test_contacts.py
+++ b/src/aipass/ai_mail/tests/test_contacts.py
@@ -112,7 +112,7 @@ def test_register_contact_updates_existing(isolated_contacts):
     register_contact("devpulse", "AIPass", "/path/to/inbox.json")
     first = get_contact("devpulse")
     assert first is not None
-    first_seen = first["last_seen"]
+    assert "last_seen" in first
 
     # Re-register with new path
     register_contact("devpulse", "AIPass", "/new/path/inbox.json")

--- a/src/aipass/cli/tests/test_init_project.py
+++ b/src/aipass/cli/tests/test_init_project.py
@@ -173,7 +173,7 @@ class TestHandleInit:
              patch.object(display, "err_console", err_cons), \
              patch.object(display, "_TRIGGER", None), \
              patch.object(display, "_TRIGGER_LOADED", True), \
-             patch.object(init_project, "json_handler") as mock_json, \
+             patch.object(init_project, "json_handler"), \
              patch.object(init_project, "logger"):
             result = _handle_init([])
 

--- a/src/aipass/cli/tests/test_templates.py
+++ b/src/aipass/cli/tests/test_templates.py
@@ -107,7 +107,7 @@ class TestOperationStart:
         assert "Simple op" in output
         lines = [line.strip() for line in output.splitlines() if line.strip()]
         # Only the operation line should have content; no "key: value" lines
-        detail_lines = [l for l in lines if ": " in l and "Simple op" not in l]
+        detail_lines = [line for line in lines if ": " in line and "Simple op" not in line]
         assert len(detail_lines) == 0
 
 
@@ -163,11 +163,11 @@ class TestOperationComplete:
         assert "Summary:" in output
         # No key-value summary lines should appear after "Summary:"
         lines = output.splitlines()
-        summary_idx = next(i for i, l in enumerate(lines) if "Summary:" in l)
+        summary_idx = next(i for i, line in enumerate(lines) if "Summary:" in line)
         after_summary = [
-            l.strip() for l in lines[summary_idx + 1:] if l.strip()
+            line.strip() for line in lines[summary_idx + 1:] if line.strip()
         ]
-        kv_lines = [l for l in after_summary if ": " in l]
+        kv_lines = [line for line in after_summary if ": " in line]
         assert len(kv_lines) == 0
 
 

--- a/src/aipass/devpulse/tests/test_feedback_inbox.py
+++ b/src/aipass/devpulse/tests/test_feedback_inbox.py
@@ -78,7 +78,7 @@ class TestListMessages:
             "unread_count": 0,
             "messages": [],
         })
-        list_messages_output = inbox.list_messages()
+        inbox.list_messages()
         # list_messages prints to stderr via Rich Console
         # We just verify it doesn't raise
 

--- a/src/aipass/devpulse/tests/test_watchdog_agent.py
+++ b/src/aipass/devpulse/tests/test_watchdog_agent.py
@@ -76,7 +76,7 @@ def test_watch_agent_branch_not_found(monkeypatch, tmp_path):
 
 def test_watch_agent_no_active_lock(monkeypatch, tmp_path):
     """No lock file -> agent already idle, returns completed immediately."""
-    branch_path = _build_fake_branch(tmp_path)
+    _build_fake_branch(tmp_path)
     monkeypatch.setattr(agent_handler, "_find_repo_root", lambda *a, **kw: tmp_path)
 
     result = agent_handler.watch_agent("@fakebranch", timeout_seconds=5)

--- a/src/aipass/drone/tests/test_module_registry.py
+++ b/src/aipass/drone/tests/test_module_registry.py
@@ -137,7 +137,7 @@ class TestHandleCommandList:
             patch(f"{_MOD}.list_modules", return_value=["alpha"]),
             patch(f"{_MOD}.get_module_info", return_value=info),
             patch(f"{_MOD}.console") as mock_console,
-            patch(f"{_MOD}.json_handler") as mock_jh,
+            patch(f"{_MOD}.json_handler"),
         ):
             from aipass.drone.apps.modules.module_registry import handle_command
 
@@ -155,7 +155,7 @@ class TestHandleCommandList:
             patch(f"{_MOD}.list_modules", return_value=["broken"]),
             patch(f"{_MOD}.get_module_info", return_value=None),
             patch(f"{_MOD}.console") as mock_console,
-            patch(f"{_MOD}.json_handler") as mock_jh,
+            patch(f"{_MOD}.json_handler"),
         ):
             from aipass.drone.apps.modules.module_registry import handle_command
 
@@ -178,7 +178,7 @@ class TestHandleCommandList:
             patch(f"{_MOD}.list_modules", return_value=["aaa", "bbb"]),
             patch(f"{_MOD}.get_module_info", side_effect=side_effect),
             patch(f"{_MOD}.console") as mock_console,
-            patch(f"{_MOD}.json_handler") as mock_jh,
+            patch(f"{_MOD}.json_handler"),
         ):
             from aipass.drone.apps.modules.module_registry import handle_command
 
@@ -192,7 +192,7 @@ class TestHandleCommandList:
         with (
             patch(f"{_MOD}.list_modules", return_value=[]),
             patch(f"{_MOD}.console") as mock_console,
-            patch(f"{_MOD}.json_handler") as mock_jh,
+            patch(f"{_MOD}.json_handler"),
         ):
             from aipass.drone.apps.modules.module_registry import handle_command
 
@@ -229,7 +229,7 @@ class TestHandleCommandInfo:
         """'info' with no args logs a warning and returns False."""
         with (
             patch(f"{_MOD}.logger") as mock_logger,
-            patch(f"{_MOD}.json_handler") as mock_jh,
+            patch(f"{_MOD}.json_handler"),
         ):
             from aipass.drone.apps.modules.module_registry import handle_command
 
@@ -243,7 +243,7 @@ class TestHandleCommandInfo:
         with (
             patch(f"{_MOD}.get_module_info", return_value=None),
             patch(f"{_MOD}.logger") as mock_logger,
-            patch(f"{_MOD}.json_handler") as mock_jh,
+            patch(f"{_MOD}.json_handler"),
         ):
             from aipass.drone.apps.modules.module_registry import handle_command
 
@@ -263,7 +263,7 @@ class TestHandleCommandInfo:
         with (
             patch(f"{_MOD}.get_module_info", return_value=info),
             patch(f"{_MOD}.console") as mock_console,
-            patch(f"{_MOD}.json_handler") as mock_jh,
+            patch(f"{_MOD}.json_handler"),
         ):
             from aipass.drone.apps.modules.module_registry import handle_command
 
@@ -303,7 +303,7 @@ class TestHandleCommandCheck:
         """'check' with no args logs a warning and returns False."""
         with (
             patch(f"{_MOD}.logger") as mock_logger,
-            patch(f"{_MOD}.json_handler") as mock_jh,
+            patch(f"{_MOD}.json_handler"),
         ):
             from aipass.drone.apps.modules.module_registry import handle_command
 
@@ -317,7 +317,7 @@ class TestHandleCommandCheck:
         with (
             patch(f"{_MOD}.is_module", return_value=True),
             patch(f"{_MOD}.console") as mock_console,
-            patch(f"{_MOD}.json_handler") as mock_jh,
+            patch(f"{_MOD}.json_handler"),
         ):
             from aipass.drone.apps.modules.module_registry import handle_command
 
@@ -333,7 +333,7 @@ class TestHandleCommandCheck:
         with (
             patch(f"{_MOD}.is_module", return_value=False),
             patch(f"{_MOD}.console") as mock_console,
-            patch(f"{_MOD}.json_handler") as mock_jh,
+            patch(f"{_MOD}.json_handler"),
         ):
             from aipass.drone.apps.modules.module_registry import handle_command
 
@@ -372,7 +372,7 @@ class TestHandleCommandUnknown:
         """An unrecognized command returns False."""
         with (
             patch(f"{_MOD}.logger") as mock_logger,
-            patch(f"{_MOD}.json_handler") as mock_jh,
+            patch(f"{_MOD}.json_handler"),
         ):
             from aipass.drone.apps.modules.module_registry import handle_command
 

--- a/src/aipass/flow/apps/handlers/mbank/process.py
+++ b/src/aipass/flow/apps/handlers/mbank/process.py
@@ -168,7 +168,7 @@ def is_template_content(content: str) -> bool:
     exec_match = re.search(r'## Execution Log\s*\n(.*?)(?=\n---|\n## |\Z)', content, re.DOTALL)
     if exec_match:
         exec_content = exec_match.group(1).strip()
-        lines = [l.strip() for l in exec_content.split('\n') if l.strip()]
+        lines = [line.strip() for line in exec_content.split('\n') if line.strip()]
         # Template has ~6 lines (date header + checkbox items). More = user added content.
         if len(lines) > 8:
             return False

--- a/src/aipass/flow/tests/test_json_handler.py
+++ b/src/aipass/flow/tests/test_json_handler.py
@@ -387,7 +387,6 @@ class TestInfrastructureMocking:
     def test_reimport_after_mock_preserves_function(self):
         """importlib.reload preserves function availability."""
         handler = _import_handler()
-        original_validate = handler.validate_json_structure
         importlib.reload(handler)
         assert callable(handler.validate_json_structure)
 

--- a/src/aipass/flow/tests/test_list_plans.py
+++ b/src/aipass/flow/tests/test_list_plans.py
@@ -89,7 +89,7 @@ class TestHandleCommandRouting:
         """Unknown filter arg should default to 'open' and emit a warning."""
         with patch(f"{_MOD}.list_plans") as mock_lp, \
              patch(f"{_MOD}.warning") as mock_warn, \
-             patch(f"{_MOD}.console") as mock_console:
+             patch(f"{_MOD}.console"):
             from aipass.flow.apps.modules.list_plans import handle_command
 
             result = handle_command("list", ["garbage"])

--- a/src/aipass/flow/tests/test_monitor_registry.py
+++ b/src/aipass/flow/tests/test_monitor_registry.py
@@ -197,7 +197,7 @@ class TestScanPlanFilesImpl:
         mod = _import_monitor_ops()
         new_dir = tmp_path / "new_location"
         new_dir.mkdir()
-        plan = _make_plan_file(new_dir, "0001")
+        _make_plan_file(new_dir, "0001")
 
         registry = {
             "plans": {

--- a/src/aipass/memory/apps/handlers/intake/pool_processor.py
+++ b/src/aipass/memory/apps/handlers/intake/pool_processor.py
@@ -254,7 +254,6 @@ def process_file_to_vectors(file_path: Path, collection_name: str, chunk_size: i
 
         # Generate embeddings and store
         documents = []
-        embeddings_list = []
         ids = []
         metadatas = []
 

--- a/src/aipass/memory/apps/handlers/schema/normalize.py
+++ b/src/aipass/memory/apps/handlers/schema/normalize.py
@@ -99,10 +99,9 @@ def normalize_memory_file(file_path: Path, dry_run: bool = False) -> Dict[str, A
         changes.append("Removed redundant 'auto_compress_at'")
 
     # 4. Remove unused limits fields (max_word_count, max_token_count - no code uses these)
-    # Preserve v2 fields: max_sessions, max_key_learnings, session_summary_max_chars, learning_value_max_chars
+    # Preserve v2 fields: max_sessions, max_key_learnings, session_summary_max_chars, learning_value_max_chars,
+    # max_observations, max_lines, note
     if 'limits' in metadata:
-        v2_fields = {'max_sessions', 'max_key_learnings', 'session_summary_max_chars',
-                      'learning_value_max_chars', 'max_observations', 'max_lines', 'note'}
         for unused_field in ['max_word_count', 'max_token_count']:
             if unused_field in metadata['limits']:
                 del metadata['limits'][unused_field]

--- a/src/aipass/memory/tests/test_json_handler.py
+++ b/src/aipass/memory/tests/test_json_handler.py
@@ -46,8 +46,8 @@ def _fresh_json_handler(monkeypatch):
     restore the real module for direct testing via importlib.reload.
     """
     saved_json_pkg = sys.modules.pop("aipass.memory.apps.handlers.json", None)
-    saved_jh = sys.modules.pop("aipass.memory.apps.handlers.json.json_handler", None)
-    saved_mf = sys.modules.pop("aipass.memory.apps.handlers.json.memory_files", None)
+    sys.modules.pop("aipass.memory.apps.handlers.json.json_handler", None)
+    sys.modules.pop("aipass.memory.apps.handlers.json.memory_files", None)
 
     try:
         pass  # noqa: F811

--- a/src/aipass/memory/tests/test_memory_files.py
+++ b/src/aipass/memory/tests/test_memory_files.py
@@ -46,20 +46,16 @@ def _fresh_memory_files(monkeypatch):
     2. Temporarily restoring the REAL json package so importlib can find
        the submodule.
     """
-    # Remember what the conftest put in for the json package
-    mock_json_pkg = sys.modules.get("aipass.memory.apps.handlers.json")
-
     # If the real package was ever imported, restore it for the duration
     # of the import.  Otherwise, remove the mock so Python can discover
     # the real package on disk.
-    real_json_pkg = None
     # Try to find the real package by importing with the mock removed
     saved = sys.modules.pop("aipass.memory.apps.handlers.json", None)
-    saved_mf = sys.modules.pop("aipass.memory.apps.handlers.json.memory_files", None)
+    sys.modules.pop("aipass.memory.apps.handlers.json.memory_files", None)
 
     try:
         # Import the real package so memory_files can be found
-        real_json_pkg = sys.modules.get("aipass.memory.apps.handlers.json")
+        sys.modules.get("aipass.memory.apps.handlers.json")
     except Exception:
         # If we can't import the real package, restore the mock
         if saved is not None:

--- a/src/aipass/memory/tests/test_templates.py
+++ b/src/aipass/memory/tests/test_templates.py
@@ -421,8 +421,8 @@ class TestHandleCommand:
         templates, mocks = _import_templates(monkeypatch)
 
         with (
-            patch.object(templates, "_display_push_results") as mock_display,
-            patch.object(templates, "_display_spawn_push_results") as mock_spawn_display,
+            patch.object(templates, "_display_push_results"),
+            patch.object(templates, "_display_spawn_push_results"),
         ):
             result = templates.handle_command("templates", ["push-templates"])
 
@@ -472,7 +472,7 @@ class TestHandleCommand:
         """'templates template-status' calls status handler."""
         templates, mocks = _import_templates(monkeypatch)
 
-        with patch.object(templates, "_display_status") as mock_display:
+        with patch.object(templates, "_display_status"):
             result = templates.handle_command("templates", ["template-status"])
 
         mocks["pusher"].get_template_status.assert_called_once()

--- a/src/aipass/prax/apps/handlers/monitoring/filesystem_handler.py
+++ b/src/aipass/prax/apps/handlers/monitoring/filesystem_handler.py
@@ -453,7 +453,7 @@ class MonitoringFileHandler(FileSystemEventHandler):
             f.seek(last_pos)
             new_data = f.read()
             self._jsonl_positions[path_key] = f.tell()
-        lines = [l for l in new_data.strip().split('\n') if l.strip()]
+        lines = [line for line in new_data.strip().split('\n') if line.strip()]
         return lines if lines else None
 
     def _safe_parse_json(self, line: str, label: str) -> Optional[dict]:
@@ -535,7 +535,7 @@ class MonitoringFileHandler(FileSystemEventHandler):
                 new_data = f.read()
                 self._jsonl_positions[path_key] = f.tell()
 
-            lines = [l for l in new_data.strip().split('\n') if l.strip()]
+            lines = [line for line in new_data.strip().split('\n') if line.strip()]
             if not lines:
                 return True
 

--- a/src/aipass/seedgo/.seedgo/bypass.json
+++ b/src/aipass/seedgo/.seedgo/bypass.json
@@ -6,6 +6,16 @@
   },
   "bypass": [
     {
+      "file": "tests/test_checkers_batch5.py",
+      "standard": "architecture",
+      "reason": "Test file lives in tests/ by convention — outside the 3-layer apps/ structure by design."
+    },
+    {
+      "file": "tests/test_checkers_batch5.py",
+      "standard": "encapsulation",
+      "reason": "Unit tests must import handlers directly to test them in isolation. Same pattern as test_checkers_batch4.py."
+    },
+    {
       "file": "_content.py",
       "reason": "Content files contain Rich markup strings with code examples (print(), python3, imports, logger calls, etc.). These are documentation, not executable code. All code-quality checkers produce false positives on these files."
     },

--- a/src/aipass/seedgo/apps/handlers/aipass_standards/imports_check.py
+++ b/src/aipass/seedgo/apps/handlers/aipass_standards/imports_check.py
@@ -101,7 +101,7 @@ def check_module(module_path: str, bypass_rules: list | None = None) -> Dict:
 
     is_handler = '/handlers/' in module_path
     is_init_file = path.name == '__init__.py'
-    is_small_file = len([l for l in lines if l.strip() and not l.strip().startswith('#')]) < 20
+    is_small_file = len([line for line in lines if line.strip() and not line.strip().startswith('#')]) < 20
 
     # Check 1: No AIPASS_ROOT (pip packages must not use it)
     if not is_init_file:

--- a/src/aipass/seedgo/apps/handlers/aipass_standards/ruff_check.md
+++ b/src/aipass/seedgo/apps/handlers/aipass_standards/ruff_check.md
@@ -1,0 +1,161 @@
+# Ruff Check Standard
+**Status:** Draft v1
+**Date:** 2026-04-16
+
+---
+
+## What This Standard Is
+
+Ruff is the primary linter for AIPass code. Seedgo can report 100% clean while a branch carries hundreds of ruff violations — this standard closes that gap. It runs `ruff check` once per branch and scores based on violation count.
+
+This standard is **advisory**: it surfaces violations and affects branch scores but never blocks an audit. It exists to prevent ruff debt from silently re-accumulating after a cleanup.
+
+---
+
+## Why It Matters
+
+- **Prevents regression.** After devpulse cleaned 338 ruff errors across 3 PRs, this standard ensures they don't drift back silently.
+- **Closes the seedgo gap.** Other standards cover AIPass-specific patterns. Ruff covers Python best practices, unused imports, undefined names, complexity, and more.
+- **Automated prevention is cheaper than cleanup.** Catching violations at audit time is far cheaper than periodic bulk cleanups.
+
+---
+
+## What the Checker Does
+
+1. Checks for ruff binary via `shutil.which("ruff")` — skips gracefully if not installed
+2. Runs `ruff check <branch>/apps/ --output-format=json`
+3. Parses JSON output — a list of violation objects with `{code, filename, location, message}`
+4. Filters violations against `.seedgo/ruff_bypass.json` (ruff-specific bypass)
+5. Scores based on non-bypassed violation count
+
+### Graceful Degradation
+
+| Condition | Behavior |
+|-----------|----------|
+| ruff not installed | SKIP — score 100, no penalty |
+| subprocess timeout (60s) | FAIL — score 0 |
+| JSON parse failure | FAIL — score 0, stderr shown |
+
+---
+
+## Scoring
+
+| Violations | Score |
+|-----------|-------|
+| 0 | 100 |
+| 1–5 | 95 |
+| 6–20 | 85 |
+| 21–50 | 70 |
+| 51–100 | 50 |
+| 101+ | 25 |
+
+---
+
+## Advisory Mode
+
+`ADVISORY = True` — `passed` is always `True`. The score reflects reality, but the audit never fails because of this standard alone.
+
+Promotion path: once all 11 branches hold at score 100 for two or more consecutive PR cycles, promote by removing the `passed = True` override and switching to `passed = score >= 75`.
+
+---
+
+## Audit Scope
+
+`AUDIT_SCOPE = "branch_level"` — runs once per branch, not per file. Ruff walks the `apps/` directory itself. Respects the branch's own `pyproject.toml` or `ruff.toml` if present.
+
+---
+
+## Bypass — Standard Level
+
+Add to `.seedgo/bypass.json` to skip ruff_check entirely for a branch:
+
+```json
+{"standard": "ruff_check", "file": "src/aipass/<branch>"}
+```
+
+---
+
+## Bypass — Ruff-Specific
+
+For fine-grained filtering, add entries to `.seedgo/ruff_bypass.json`. This file is a JSON array. All fields are optional — omitting a field means "match any".
+
+### Examples
+
+Skip all E501 violations in one file:
+
+```json
+[
+    {"file": "apps/handlers/long_lines.py", "code": "E501"}
+]
+```
+
+Skip a single violation at a specific line:
+
+```json
+[
+    {"file": "apps/modules/thing.py", "code": "F401", "line": 42}
+]
+```
+
+Skip all violations in a generated or vendor file:
+
+```json
+[
+    {"file": "apps/handlers/generated.py"}
+]
+```
+
+### Bypass Rule Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `file` | string | Partial path match against violation's `filename`. Omit to match any file. |
+| `code` | string | Exact ruff code (e.g., `"E501"`, `"F401"`). Omit to match any code. |
+| `line` | int | Line number. Omit to match any line. |
+
+---
+
+## Code Examples
+
+### Violation (F401 — unused import)
+
+```python
+import os  # never used
+import json
+
+def load_data(path):
+    return json.loads(path.read_text())
+```
+
+### Fix
+
+```python
+import json  # removed unused 'os'
+
+def load_data(path):
+    return json.loads(path.read_text())
+```
+
+### Violation (E741 — ambiguous variable name)
+
+```python
+for l in lines:
+    process(l)
+```
+
+### Fix
+
+```python
+for line in lines:
+    process(line)
+```
+
+---
+
+## Reference
+
+- Checker: `ruff_check.py`
+- Content handler: `ruff_check_content.py`
+- Standards pack: seedgo standards (ruff_check)
+- Ruff documentation: https://docs.astral.sh/ruff/
+- Ruff rules reference: https://docs.astral.sh/ruff/rules/

--- a/src/aipass/seedgo/apps/handlers/aipass_standards/ruff_check.py
+++ b/src/aipass/seedgo/apps/handlers/aipass_standards/ruff_check.py
@@ -1,0 +1,226 @@
+# =================== AIPass ====================
+# Name: ruff_check.py
+# Description: Ruff Linter Standards Checker Handler
+# Version: 1.0.0
+# Created: 2026-04-16
+# Modified: 2026-04-16
+# =============================================
+
+"""
+Ruff Linter Standards Checker Handler
+
+Runs ruff against a branch's apps/ directory and scores based on violation
+count. Prevents ruff debt from silently re-accumulating after a cleanup.
+
+AUDIT_SCOPE: branch_level — runs once per branch, ruff walks the tree.
+ADVISORY: surfaces violations and score but always passes overall.
+          Promote to required once all branches are clean.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict
+
+from aipass.prax import logger
+from aipass.seedgo.apps.handlers.json import json_handler
+
+AUDIT_SCOPE = "branch_level"
+ADVISORY = True
+
+
+def is_bypassed(file_path: str, standard: str, bypass_rules: list | None = None) -> bool:
+    """Check if a violation should be bypassed via standard bypass.json rules."""
+    if not bypass_rules:
+        return False
+    for rule in bypass_rules:
+        if rule.get("standard") and rule.get("standard") != standard:
+            continue
+        rule_file = rule.get("file", "")
+        if rule_file and rule_file not in file_path:
+            continue
+        return True
+    return False
+
+
+def _load_ruff_bypass(branch_path: Path) -> list:
+    """Load .seedgo/ruff_bypass.json for ruff-specific bypass rules."""
+    bypass_file = branch_path / ".seedgo" / "ruff_bypass.json"
+    if not bypass_file.exists():
+        return []
+    try:
+        data = json.loads(bypass_file.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except Exception as exc:
+        logger.warning("Failed to load ruff_bypass.json: %s", exc)
+        return []
+
+
+def _is_ruff_bypassed(violation: dict, ruff_bypass: list) -> bool:
+    """Check if a single ruff violation matches any ruff-specific bypass rule.
+
+    Bypass rule format: {"file": "partial/path.py", "code": "E501", "line": 42}
+    All fields optional — omitting a field means "match any".
+    """
+    v_file = violation.get("filename", "")
+    v_code = violation.get("code", "")
+    v_line = violation.get("location", {}).get("row")
+    for rule in ruff_bypass:
+        rule_file = rule.get("file", "")
+        if rule_file and rule_file not in v_file:
+            continue
+        rule_code = rule.get("code", "")
+        if rule_code and rule_code != v_code:
+            continue
+        rule_line = rule.get("line")
+        if rule_line is not None and v_line != rule_line:
+            continue
+        return True
+    return False
+
+
+def _score_from_count(count: int) -> int:
+    """Map violation count to a 0–100 score."""
+    if count == 0:
+        return 100
+    if count <= 5:
+        return 95
+    if count <= 20:
+        return 85
+    if count <= 50:
+        return 70
+    if count <= 100:
+        return 50
+    return 25
+
+
+def check_branch(branch_path: str, bypass_rules: list | None = None) -> Dict:
+    """Run ruff against the branch and score based on violation count.
+
+    Args:
+        branch_path: Path to branch root (e.g., src/aipass/seedgo)
+        bypass_rules: Standard bypass rules from .seedgo/bypass.json
+
+    Returns:
+        dict: {
+            'passed': bool (always True — advisory mode),
+            'checks': [{'name': str, 'passed': bool, 'message': str}],
+            'score': int,
+            'standard': 'RUFF_CHECK',
+            'advisory': True
+        }
+    """
+    bp = Path(branch_path)
+
+    # Standard-level bypass
+    if is_bypassed(branch_path, "ruff_check", bypass_rules=bypass_rules):
+        json_handler.log_operation(
+            "check_completed",
+            {"branch": branch_path, "score": 100, "standard": "ruff_check"},
+        )
+        return {
+            "passed": True,
+            "checks": [{"name": "Ruff check", "passed": True,
+                        "message": "Standard bypassed via .seedgo/bypass.json"}],
+            "score": 100,
+            "standard": "RUFF_CHECK",
+            "advisory": True,
+        }
+
+    # Graceful degradation: ruff not installed
+    if shutil.which("ruff") is None:
+        json_handler.log_operation(
+            "check_completed",
+            {"branch": branch_path, "score": 100, "standard": "ruff_check", "status": "skipped"},
+        )
+        return {
+            "passed": True,
+            "checks": [{"name": "Ruff check", "passed": True,
+                        "message": "ruff not installed — check skipped"}],
+            "score": 100,
+            "status": "skipped",
+            "standard": "RUFF_CHECK",
+            "advisory": True,
+        }
+
+    # Scan apps/ if present, otherwise full branch
+    scan_target = bp / "apps" if (bp / "apps").is_dir() else bp
+
+    # Load ruff-specific bypass rules
+    ruff_bypass = _load_ruff_bypass(bp)
+
+    # Run ruff
+    try:
+        proc = subprocess.run(
+            ["ruff", "check", str(scan_target), "--output-format=json"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("ruff check timed out on branch %s", branch_path)
+        json_handler.log_operation(
+            "check_completed",
+            {"branch": branch_path, "score": 0, "standard": "ruff_check", "error": "timeout"},
+        )
+        return {
+            "passed": False,
+            "checks": [{"name": "Ruff check", "passed": False,
+                        "message": "ruff check timed out after 60s"}],
+            "score": 0,
+            "standard": "RUFF_CHECK",
+            "advisory": True,
+        }
+
+    # Parse JSON output (ruff exits 0=clean, 1=violations, 2+=error)
+    violations: list = []
+    if proc.stdout.strip():
+        try:
+            violations = json.loads(proc.stdout)
+            if not isinstance(violations, list):
+                violations = []
+        except (json.JSONDecodeError, ValueError):
+            stderr_snippet = proc.stderr[:300] if proc.stderr else "(no stderr)"
+            logger.warning("ruff JSON parse failed on %s: %s", branch_path, stderr_snippet)
+            json_handler.log_operation(
+                "check_completed",
+                {"branch": branch_path, "score": 0, "standard": "ruff_check", "error": "json_parse"},
+            )
+            return {
+                "passed": False,
+                "checks": [{"name": "Ruff check", "passed": False,
+                            "message": f"ruff JSON parse failed: {stderr_snippet}"}],
+                "score": 0,
+                "standard": "RUFF_CHECK",
+                "advisory": True,
+            }
+
+    # Filter bypassed violations
+    active = [v for v in violations if not _is_ruff_bypassed(v, ruff_bypass)]
+    count = len(active)
+    score = _score_from_count(count)
+
+    if count == 0:
+        message = "No ruff violations found"
+        check_passed = True
+    else:
+        top = active[:5]
+        codes = ", ".join(f"{v.get('code', '?')} {Path(v.get('filename', '?')).name}:{v.get('location', {}).get('row', '?')}" for v in top)
+        suffix = f" (and {count - 5} more)" if count > 5 else ""
+        message = f"{count} violation(s) — {codes}{suffix}"
+        check_passed = False
+
+    json_handler.log_operation(
+        "check_completed",
+        {"branch": branch_path, "score": score, "standard": "ruff_check",
+         "violations": count, "advisory": True},
+    )
+
+    return {
+        "passed": True,  # Advisory: never blocks the audit
+        "checks": [{"name": "Ruff check", "passed": check_passed, "message": message}],
+        "score": score,
+        "standard": "RUFF_CHECK",
+        "advisory": True,
+    }

--- a/src/aipass/seedgo/apps/handlers/aipass_standards/ruff_check_content.py
+++ b/src/aipass/seedgo/apps/handlers/aipass_standards/ruff_check_content.py
@@ -1,0 +1,104 @@
+# =================== AIPass ====================
+# Name: ruff_check_content.py
+# Description: Ruff Check Standards Content Handler
+# Version: 1.0.0
+# Created: 2026-04-16
+# Modified: 2026-04-16
+# =============================================
+
+"""
+Ruff Check Standards Content Handler
+
+Provides formatted ruff_check standards content.
+Module orchestrates, handler implements.
+"""
+
+from aipass.seedgo.apps.handlers.json import json_handler
+
+
+def get_ruff_check_standards() -> str:
+    """Return formatted ruff_check standards content with Rich markup.
+
+    Returns:
+        str: Formatted standards text with Rich styling
+    """
+    lines = [
+        "[bold cyan]CORE PRINCIPLE:[/bold cyan]",
+        "  Ruff is the primary linter for AIPass code. Zero violations is the bar.",
+        "  Code that passes seedgo can still have 338 ruff violations — this standard",
+        "  closes that gap. Advisory initially: surfaces violations, never blocks.",
+        "",
+        "[bold cyan]WHAT IT CHECKS:[/bold cyan]",
+        "  Runs [dim]ruff check <branch>/apps/ --output-format=json[/dim] and scores",
+        "  based on violation count. Covers the full ruff rule set: unused imports,",
+        "  undefined names, style, complexity, security, and more.",
+        "",
+        "  [green]Graceful degradation:[/green]",
+        "  - ruff not installed → SKIP (score 100, no penalty)",
+        "  - subprocess timeout (60s) → FAIL with score 0",
+        "  - JSON parse failure → FAIL with score 0",
+        "",
+        "[bold cyan]SCORING:[/bold cyan]",
+        "  Violation count → score:",
+        "  [green]0 violations         → 100[/green]",
+        "  [yellow]1–5 violations        → 95[/yellow]",
+        "  [yellow]6–20 violations       → 85[/yellow]",
+        "  [yellow]21–50 violations      → 70[/yellow]",
+        "  [red]51–100 violations     → 50[/red]",
+        "  [red]101+ violations       → 25[/red]",
+        "",
+        "[yellow]SCOPE:[/yellow]",
+        "  AUDIT_SCOPE = [bold]branch_level[/bold]",
+        "  Runs once per branch — ruff walks [dim]apps/[/dim] tree itself.",
+        "  Respects the branch's own [dim]pyproject.toml[/dim] or [dim]ruff.toml[/dim] if present.",
+        "",
+        "[bold cyan]ADVISORY MODE:[/bold cyan]",
+        "  This standard is currently ADVISORY — it surfaces violation counts",
+        "  and affects branch scores but never blocks an audit.",
+        "  Promotion to REQUIRED once all branches are consistently clean.",
+        "",
+        "[bold cyan]VIOLATIONS:[/bold cyan]",
+        "  Violation message format:",
+        "  [dim]3 violation(s) — E501 module.py:42, F401 handler.py:7, F841 utils.py:15[/dim]",
+        "",
+        "  [red]Common violations:[/red]",
+        "  [dim]E501[/dim]  Line too long",
+        "  [dim]F401[/dim]  Unused import",
+        "  [dim]F841[/dim]  Local variable assigned but never used",
+        "  [dim]E741[/dim]  Ambiguous variable name",
+        "  [dim]F811[/dim]  Redefinition of unused name",
+        "",
+        "  Full rule reference: [dim]https://docs.astral.sh/ruff/rules/[/dim]",
+        "",
+        "[bold cyan]HOW TO FIX:[/bold cyan]",
+        "  Run [dim]ruff check apps/[/dim] to see violations with context.",
+        "  Run [dim]ruff check apps/ --fix[/dim] to auto-fix safe violations.",
+        "  Re-run the audit to confirm score 100.",
+        "",
+        "[bold cyan]BYPASS — standard:[/bold cyan]",
+        "  Add to [dim].seedgo/bypass.json[/dim] to skip the entire standard for a branch:",
+        "  [dim]{\"standard\": \"ruff_check\", \"file\": \"src/aipass/<branch>\"}[/dim]",
+        "",
+        "[bold cyan]BYPASS — ruff-specific:[/bold cyan]",
+        "  Add to [dim].seedgo/ruff_bypass.json[/dim] for fine-grained filtering.",
+        "  All fields are optional — omit to match any value.",
+        "",
+        "  Skip all E501 in a file:",
+        "  [dim]{\"file\": \"apps/handlers/long_file.py\", \"code\": \"E501\"}[/dim]",
+        "",
+        "  Skip a single violation at a specific line:",
+        "  [dim]{\"file\": \"apps/modules/thing.py\", \"code\": \"F401\", \"line\": 42}[/dim]",
+        "",
+        "  Skip all violations in a file:",
+        "  [dim]{\"file\": \"apps/handlers/generated.py\"}[/dim]",
+        "",
+        "  File content: a JSON array of rule objects.",
+        "",
+        "[bold cyan]REFERENCE:[/bold cyan]",
+        "  [dim]Checker: ruff_check.py[/dim]",
+        "  [dim]Standards pack: seedgo standards (ruff_check)[/dim]",
+        "  [dim]Ruff docs: https://docs.astral.sh/ruff/[/dim]",
+    ]
+
+    json_handler.log_operation("standard_content_queried", {"standard": "ruff_check"})
+    return "\n".join(lines)

--- a/src/aipass/seedgo/tests/test_checkers_batch5.py
+++ b/src/aipass/seedgo/tests/test_checkers_batch5.py
@@ -1,0 +1,207 @@
+"""Tests for ruff_check.check_branch — the 33rd seedgo standard."""
+
+# =================== META ====================
+# Name: test_checkers_batch5.py
+# Description: Unit tests for ruff_check checker handler (batch 5)
+# Version: 1.0.0
+# Created: 2026-04-16
+# Modified: 2026-04-16
+# =============================================
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from aipass.seedgo.apps.handlers.aipass_standards.ruff_check import (
+    check_branch,
+    _score_from_count,
+    _is_ruff_bypassed,
+)
+
+
+# =============================================
+# HELPERS
+# =============================================
+
+def _write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_branch(tmp_path: Path) -> Path:
+    apps = tmp_path / "apps"
+    (apps / "modules").mkdir(parents=True)
+    (apps / "handlers").mkdir(parents=True)
+    return tmp_path
+
+
+def _ruff_proc(violations: list, returncode: int = 1) -> MagicMock:
+    """Build a fake subprocess.CompletedProcess with JSON output."""
+    proc = MagicMock()
+    proc.stdout = json.dumps(violations)
+    proc.stderr = ""
+    proc.returncode = returncode
+    return proc
+
+
+def _make_violation(filename: str, code: str = "F401", row: int = 1) -> dict:
+    return {
+        "filename": filename,
+        "code": code,
+        "location": {"row": row, "column": 1},
+        "end_location": {"row": row, "column": 10},
+        "message": f"Mock violation {code}",
+    }
+
+
+# =============================================
+# 1. Score helper
+# =============================================
+
+class TestScoreFromCount:
+    def test_zero_violations(self) -> None:
+        """Zero violations maps to score 100."""
+        assert _score_from_count(0) == 100
+
+    def test_one_violation(self) -> None:
+        """One violation falls in the 1–5 band, score 95."""
+        assert _score_from_count(1) == 95
+
+    def test_five_violations(self) -> None:
+        """Five violations is the upper bound of the 1–5 band, score 95."""
+        assert _score_from_count(5) == 95
+
+    def test_six_violations(self) -> None:
+        """Six violations enters the 6–20 band, score 85."""
+        assert _score_from_count(6) == 85
+
+    def test_fifty_one_violations(self) -> None:
+        """51 violations enters the 51–100 band, score 50."""
+        assert _score_from_count(51) == 50
+
+    def test_over_hundred(self) -> None:
+        """101+ violations hits the floor band, score 25."""
+        assert _score_from_count(101) == 25
+
+
+# =============================================
+# 2. Ruff bypass helper
+# =============================================
+
+class TestIsRuffBypassed:
+    def test_no_bypass_rules(self) -> None:
+        """Empty bypass list never matches any violation."""
+        v = _make_violation("/apps/module.py", "F401", 10)
+        assert not _is_ruff_bypassed(v, [])
+
+    def test_file_and_code_match(self) -> None:
+        """Rule matching file and code bypasses the violation."""
+        v = _make_violation("/apps/module.py", "F401", 10)
+        bypass = [{"file": "module.py", "code": "F401"}]
+        assert _is_ruff_bypassed(v, bypass)
+
+    def test_code_mismatch(self) -> None:
+        """Rule with different code does not bypass the violation."""
+        v = _make_violation("/apps/module.py", "F401", 10)
+        bypass = [{"file": "module.py", "code": "E501"}]
+        assert not _is_ruff_bypassed(v, bypass)
+
+    def test_line_match(self) -> None:
+        """Rule with matching line number bypasses the violation."""
+        v = _make_violation("/apps/module.py", "F401", 42)
+        bypass = [{"file": "module.py", "code": "F401", "line": 42}]
+        assert _is_ruff_bypassed(v, bypass)
+
+    def test_line_mismatch(self) -> None:
+        """Rule targeting a different line does not bypass the violation."""
+        v = _make_violation("/apps/module.py", "F401", 10)
+        bypass = [{"file": "module.py", "code": "F401", "line": 99}]
+        assert not _is_ruff_bypassed(v, bypass)
+
+    def test_file_only_matches_any_code(self) -> None:
+        """File-only rule bypasses all violations in that file regardless of code."""
+        v = _make_violation("/apps/module.py", "E501", 1)
+        bypass = [{"file": "module.py"}]
+        assert _is_ruff_bypassed(v, bypass)
+
+
+# =============================================
+# 3. check_branch
+# =============================================
+
+@patch("aipass.seedgo.apps.handlers.aipass_standards.ruff_check.json_handler")
+class TestCheckBranch:
+
+    def test_clean_branch_scores_100(self, mock_json, tmp_path: Path) -> None:
+        """Branch with zero ruff violations scores 100."""
+        branch = _make_branch(tmp_path)
+        clean_proc = _ruff_proc([], returncode=0)
+        with patch("aipass.seedgo.apps.handlers.aipass_standards.ruff_check.shutil.which", return_value="/usr/bin/ruff"):
+            with patch("aipass.seedgo.apps.handlers.aipass_standards.ruff_check.subprocess.run", return_value=clean_proc):
+                result = check_branch(str(branch))
+        assert result["score"] == 100
+        assert result["passed"] is True
+        assert result["standard"] == "RUFF_CHECK"
+        assert result["advisory"] is True
+
+    def test_violations_caught_and_scored(self, mock_json, tmp_path: Path) -> None:
+        """Branch with violations reports count and drops score."""
+        branch = _make_branch(tmp_path)
+        violations = [_make_violation(str(branch / "apps" / "modules" / "x.py"), "F401", i) for i in range(10)]
+        proc = _ruff_proc(violations, returncode=1)
+        with patch("aipass.seedgo.apps.handlers.aipass_standards.ruff_check.shutil.which", return_value="/usr/bin/ruff"):
+            with patch("aipass.seedgo.apps.handlers.aipass_standards.ruff_check.subprocess.run", return_value=proc):
+                result = check_branch(str(branch))
+        assert result["score"] == 85  # 10 violations → 6–20 band
+        assert result["passed"] is True  # advisory: always True
+        assert "10 violation" in result["checks"][0]["message"]
+
+    def test_standard_bypass_respected(self, mock_json, tmp_path: Path) -> None:
+        """Standard-level bypass via bypass_rules returns score 100."""
+        branch = _make_branch(tmp_path)
+        bypass = [{"standard": "ruff_check"}]
+        result = check_branch(str(branch), bypass_rules=bypass)
+        assert result["score"] == 100
+        assert result["passed"] is True
+
+    def test_ruff_not_installed_skips(self, mock_json, tmp_path: Path) -> None:
+        """Missing ruff binary returns score 100 with skipped status."""
+        branch = _make_branch(tmp_path)
+        with patch("aipass.seedgo.apps.handlers.aipass_standards.ruff_check.shutil.which", return_value=None):
+            result = check_branch(str(branch))
+        assert result["score"] == 100
+        assert result["passed"] is True
+        assert result.get("status") == "skipped"
+        assert "not installed" in result["checks"][0]["message"]
+
+    def test_ruff_bypass_json_filters_violations(self, mock_json, tmp_path: Path) -> None:
+        """Violations listed in .seedgo/ruff_bypass.json are filtered out."""
+        branch = _make_branch(tmp_path)
+        v_path = str(branch / "apps" / "modules" / "thing.py")
+        violations = [
+            _make_violation(v_path, "F401", 1),
+            _make_violation(v_path, "E501", 10),
+        ]
+        proc = _ruff_proc(violations, returncode=1)
+        # Bypass the F401
+        bypass_file = branch / ".seedgo" / "ruff_bypass.json"
+        bypass_file.parent.mkdir(parents=True, exist_ok=True)
+        bypass_file.write_text(json.dumps([{"file": "thing.py", "code": "F401"}]))
+        with patch("aipass.seedgo.apps.handlers.aipass_standards.ruff_check.shutil.which", return_value="/usr/bin/ruff"):
+            with patch("aipass.seedgo.apps.handlers.aipass_standards.ruff_check.subprocess.run", return_value=proc):
+                result = check_branch(str(branch))
+        # Only 1 active violation (E501), score should be 95
+        assert result["score"] == 95
+        assert "1 violation" in result["checks"][0]["message"]
+
+    def test_timeout_returns_score_zero(self, mock_json, tmp_path: Path) -> None:
+        """Subprocess timeout returns score 0 and passed False."""
+        import subprocess as sp
+        branch = _make_branch(tmp_path)
+        with patch("aipass.seedgo.apps.handlers.aipass_standards.ruff_check.shutil.which", return_value="/usr/bin/ruff"):
+            with patch("aipass.seedgo.apps.handlers.aipass_standards.ruff_check.subprocess.run",
+                       side_effect=sp.TimeoutExpired(cmd="ruff", timeout=60)):
+                result = check_branch(str(branch))
+        assert result["score"] == 0
+        assert result["passed"] is False
+        assert "timed out" in result["checks"][0]["message"]


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- chore(lint)+feat(seedgo): ruff F841+E741 cleanup (36 errors) + ruff_check as seedgo's 33rd standard — combined replacement for #334/#335/#336 invalidated by #333 squash-merge
- 3 commit(s) ahead of origin/main
