### PR TITLE
feat(system): fix(drone): AIPASS_HOME fallback in _cwd_has_registry — lets drone find registry when invoked from external projects / global usage. Additive only. Cherry-picked from #328 after testing. (Rejected #328's bare-branch auto-route which broke the @ contract.)

### DIFF
--- a/src/aipass/drone/apps/drone.py
+++ b/src/aipass/drone/apps/drone.py
@@ -150,6 +150,12 @@ def _cwd_has_registry(max_depth: int = 10) -> bool:
             break
         if list(parent.glob("*_REGISTRY.json")):
             return True
+    # AIPASS_HOME fallback — for external projects / global drone usage
+    aipass_home = os.environ.get("AIPASS_HOME")
+    if aipass_home:
+        home = Path(aipass_home)
+        if home.is_dir() and list(home.glob("*_REGISTRY.json")):
+            return True
     return False
 
 


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- fix(drone): AIPASS_HOME fallback in _cwd_has_registry — lets drone find registry when invoked from external projects / global usage. Additive only. Cherry-picked from #328 after testing. (Rejected #328's bare-branch auto-route which broke the @ contract.)
- 1 commit(s) ahead of origin/main
