### PR TITLE
feat(seedgo): fix(bypass): resolve relative registry paths in get_branch_from_path and _load_bypass_for_file — bypass.json entries silently failed for all checklist invocations because branch paths from registry are relative (src/aipass/seedgo) but were compared directly against absolute resolved file paths

### DIFF
--- a/src/aipass/seedgo/apps/handlers/bypass/bypass_handler.py
+++ b/src/aipass/seedgo/apps/handlers/bypass/bypass_handler.py
@@ -94,11 +94,23 @@ def get_branch_from_path(file_path: str) -> Optional[Dict[str, Any]]:
 
         file_path = str(Path(file_path).resolve())
 
-        # Sort branches by path length (longest first) to match most specific
-        branches = sorted(registry.get("branches", []), key=lambda b: len(b.get("path", "")), reverse=True)
+        registry_dir = REGISTRY_PATH.parent
+
+        def _resolve(raw: str) -> str:
+            p = Path(raw)
+            if not p.is_absolute():
+                p = (registry_dir / p).resolve()
+            return str(p)
+
+        # Sort branches by resolved path length (longest first) to match most specific
+        branches = sorted(
+            registry.get("branches", []),
+            key=lambda b: len(_resolve(b.get("path", ""))),
+            reverse=True,
+        )
 
         for branch in branches:
-            branch_path = branch.get("path", "")
+            branch_path = _resolve(branch.get("path", ""))
             if file_path.startswith(branch_path + "/") or file_path == branch_path:
                 return branch
 

--- a/src/aipass/seedgo/apps/modules/checklist.py
+++ b/src/aipass/seedgo/apps/modules/checklist.py
@@ -181,13 +181,18 @@ def _resolve_pack_path(pack_name: str) -> Optional[Path]:
 
 def _load_bypass_for_file(file_path: str) -> list:
     """Load bypass rules for the branch containing file_path."""
+    from aipass.seedgo.apps.handlers.bypass.bypass_handler import REGISTRY_PATH
+
     branch = get_branch_from_path(file_path)
     if branch is None:
         return []
-    branch_path = branch.get("path", "")
-    if not branch_path:
+    raw_path = branch.get("path", "")
+    if not raw_path:
         return []
-    return load_bypass_rules(branch_path)
+    bp = Path(raw_path)
+    if not bp.is_absolute():
+        bp = (REGISTRY_PATH.parent / bp).resolve()
+    return load_bypass_rules(str(bp))
 
 
 def _format_failure(result: Dict) -> str:


### PR DESCRIPTION
## Summary

- fix(bypass): resolve relative registry paths in get_branch_from_path and _load_bypass_for_file — bypass.json entries silently failed for all checklist invocations because branch paths from registry are relative (src/aipass/seedgo) but were compared directly against absolute resolved file paths

## Branch

Created by @seedgo via `drone @git pr`
