### PR TITLE
feat(daemon): recognize AIPASS-TEST ping token — auto-ack without spawning (Phase 3.5)

### DIFF
--- a/src/aipass/ai_mail/.seedgo/bypass.json
+++ b/src/aipass/ai_mail/.seedgo/bypass.json
@@ -324,6 +324,16 @@
       "file": "tests/test_wake.py",
       "standard": "documentation",
       "reason": "Test helper functions (_fake_open_factory, _raise_process_lookup, repo_root fixture) are private test infrastructure — docstring requirement does not apply to test helpers."
+    },
+    {
+      "file": "tests/test_daemon.py",
+      "standard": "architecture",
+      "reason": "Test file lives in tests/ directory — not subject to 3-layer app structure rule."
+    },
+    {
+      "file": "tests/test_daemon.py",
+      "standard": "encapsulation",
+      "reason": "Unit tests must import handlers directly to exercise internal functions (_has_test_token, scan_and_ack_test_emails, _auto_ack_test_email, poll_cycle). Module entry-point-only rule does not apply to tests."
     }
   ],
   "notes": {

--- a/src/aipass/ai_mail/apps/handlers/dispatch/daemon.py
+++ b/src/aipass/ai_mail/apps/handlers/dispatch/daemon.py
@@ -37,6 +37,9 @@ from aipass.ai_mail.apps.handlers.dispatch.status import log_dispatch
 from aipass.ai_mail.apps.handlers.paths import find_repo_root
 
 
+# Test-convention token — @aipass ping protocol (DPLAN-0136 / FPLAN-0188 Phase 3.5)
+TEST_TOKEN = "[AIPASS-TEST — do not update memories, do not execute, reply 'ack' only]"
+
 # Infrastructure paths
 _REPO_ROOT = find_repo_root()
 _AI_MAIL_DIR = Path(__file__).resolve().parents[3]  # ai_mail/
@@ -177,6 +180,97 @@ def _check_lock(branch_path: Path) -> Optional[Dict[str, Any]]:
         logger.warning("Corrupt lock file removed at %s", lock_file)
         lock_file.unlink(missing_ok=True)
         return None
+
+
+def _has_test_token(body: str) -> bool:
+    """Detect the AIPASS-TEST ping token in a message body.
+
+    Token must appear on its own line (leading/trailing whitespace stripped)
+    and must not be inside a markdown code block (``` fences).
+    Case-sensitive, exact match only.
+    """
+    in_code_block = False
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+            continue
+        if not in_code_block and stripped == TEST_TOKEN:
+            return True
+    return False
+
+
+def _auto_ack_test_email(branch_path: Path, branch_email: str, message: Dict[str, Any]) -> bool:
+    """Send 'ack' reply and close a test-convention ping email.
+
+    Runs drone commands with cwd=branch_path so ai_mail detects the correct
+    sender identity (the target branch, not ai_mail itself).
+
+    Returns True if the ack email was sent successfully.
+    """
+    sender = message.get("from", "")
+    subject = message.get("subject", "ping")
+    msg_id = message.get("id", "")
+
+    if not sender or not msg_id:
+        logger.warning("[daemon] TEST-ACK skipped for %s: missing sender or id", branch_email)
+        return False
+
+    # Send ack email (CWD=branch_path so sender is detected as the target branch)
+    ack_sent = False
+    try:
+        result = subprocess.run(
+            ["drone", "@ai_mail", "email", sender, f"Re: {subject}", "ack"],
+            capture_output=True, text=True, timeout=30,
+            cwd=str(branch_path),
+        )
+        ack_sent = result.returncode == 0
+        if not ack_sent:
+            logger.warning("[daemon] TEST-ACK email failed for %s→%s: %s",
+                           branch_email, sender, result.stderr[:200])
+    except (subprocess.SubprocessError, OSError) as e:
+        logger.warning("[daemon] TEST-ACK subprocess failed for %s→%s: %s", branch_email, sender, e)
+
+    # Close the test email so it doesn't get retried
+    try:
+        subprocess.run(
+            ["drone", "@ai_mail", "close", msg_id],
+            capture_output=True, text=True, timeout=15,
+            cwd=str(branch_path),
+        )
+    except (subprocess.SubprocessError, OSError) as e:
+        logger.warning("[daemon] TEST-ACK close failed for %s msg %s: %s", branch_email, msg_id, e)
+
+    logger.info("[daemon] TEST-ACK %s → %s msg=%s sent=%s", branch_email, sender, msg_id, ack_sent)
+    return ack_sent
+
+
+def scan_and_ack_test_emails(branch_path: Path, branch_email: str) -> int:
+    """Scan a branch inbox for test-convention ping emails and auto-ack them.
+
+    Processes all new/opened messages containing the TEST_TOKEN, regardless
+    of auto_execute flag. Returns count of emails handled.
+
+    Called before check_inbox_for_dispatch() in poll_cycle() so test emails
+    are closed before the dispatch scan runs.
+    """
+    inbox_file = branch_path / ".ai_mail.local" / "inbox.json"
+    inbox_data = _read_json(inbox_file)
+    if inbox_data is None:
+        return 0
+
+    count = 0
+    for msg in inbox_data.get("messages", []):
+        if msg.get("status") not in ("new", "opened"):
+            continue
+        body = msg.get("message", "")
+        if _has_test_token(body):
+            if _auto_ack_test_email(branch_path, branch_email, msg):
+                count += 1
+
+    if count:
+        logger.info("[daemon] TEST-ACK handled %d ping email(s) for %s", count, branch_email)
+    return count
 
 
 def _acquire_lock(branch_path: Path, pid: int) -> tuple[bool, str]:
@@ -556,6 +650,9 @@ def poll_cycle(config: Dict[str, Any], state: Dict[str, Any]) -> int:
         if existing_lock is not None:
             logger.info(f"SKIP {branch_email}: active lock (PID {existing_lock.get('pid', '?')})")
             continue
+
+        # Handle AIPASS-TEST ping emails before dispatch scan
+        scan_and_ack_test_emails(branch_path, branch_email)
 
         dispatch_msg = check_inbox_for_dispatch(branch_path)
         if dispatch_msg is None:

--- a/src/aipass/ai_mail/tests/test_daemon.py
+++ b/src/aipass/ai_mail/tests/test_daemon.py
@@ -507,3 +507,178 @@ def test_is_protected_branch_other():
 def test_is_protected_branch_empty_string():
     """Empty string is not protected."""
     assert is_protected_branch("") is False
+
+
+# --- AIPASS-TEST token tests -----------------------------------------
+
+
+class TestHasTestToken:
+    """Tests for _has_test_token() — exact token detection."""
+
+    TOKEN = "[AIPASS-TEST — do not update memories, do not execute, reply 'ack' only]"
+
+    def test_detects_token_alone(self):
+        """Detects token as the entire body."""
+        from aipass.ai_mail.apps.handlers.dispatch.daemon import _has_test_token
+        assert _has_test_token(self.TOKEN) is True
+
+    def test_detects_token_on_own_line(self):
+        """Detects token when surrounded by other text."""
+        from aipass.ai_mail.apps.handlers.dispatch.daemon import _has_test_token
+        body = f"Smoke test.\n{self.TOKEN}\nSome trailing text."
+        assert _has_test_token(body) is True
+
+    def test_ignores_token_with_wrong_case(self):
+        """Token match is case-sensitive."""
+        from aipass.ai_mail.apps.handlers.dispatch.daemon import _has_test_token
+        assert _has_test_token(self.TOKEN.lower()) is False
+        assert _has_test_token(self.TOKEN.upper()) is False
+
+    def test_ignores_partial_token(self):
+        """Partial token does not match."""
+        from aipass.ai_mail.apps.handlers.dispatch.daemon import _has_test_token
+        assert _has_test_token("[AIPASS-TEST]") is False
+        assert _has_test_token("do not update memories") is False
+
+    def test_ignores_token_inside_code_block(self):
+        """Token inside ``` fences is not matched."""
+        from aipass.ai_mail.apps.handlers.dispatch.daemon import _has_test_token
+        body = f"Before.\n```\n{self.TOKEN}\n```\nAfter."
+        assert _has_test_token(body) is False
+
+    def test_detects_token_outside_code_block(self):
+        """Token outside code fences is matched even when a code block exists."""
+        from aipass.ai_mail.apps.handlers.dispatch.daemon import _has_test_token
+        body = f"```\nsome code\n```\n{self.TOKEN}"
+        assert _has_test_token(body) is True
+
+    def test_returns_false_for_empty_body(self):
+        """Empty body returns False."""
+        from aipass.ai_mail.apps.handlers.dispatch.daemon import _has_test_token
+        assert _has_test_token("") is False
+
+    def test_strips_whitespace_before_comparing(self):
+        """Leading/trailing whitespace on the line is ignored."""
+        from aipass.ai_mail.apps.handlers.dispatch.daemon import _has_test_token
+        body = f"  {self.TOKEN}  "
+        assert _has_test_token(body) is True
+
+
+class TestScanAndAckTestEmails:
+    """Tests for scan_and_ack_test_emails() — inbox scan + auto-ack."""
+
+    TOKEN = "[AIPASS-TEST — do not update memories, do not execute, reply 'ack' only]"
+
+    @pytest.fixture(autouse=True)
+    def _suppress_log(self, monkeypatch):
+        monkeypatch.setattr(
+            "aipass.ai_mail.apps.handlers.dispatch.daemon.json_handler.log_operation",
+            lambda *a, **kw: None,
+        )
+
+    def _make_inbox(self, tmp_path, messages):
+        mail_dir = tmp_path / ".ai_mail.local"
+        mail_dir.mkdir()
+        inbox = mail_dir / "inbox.json"
+        inbox.write_text(json.dumps({"messages": messages}))
+        return tmp_path
+
+    def test_acks_test_token_email(self, tmp_path, monkeypatch):
+        """scan_and_ack_test_emails calls _auto_ack_test_email for test-token messages."""
+        from aipass.ai_mail.apps.handlers.dispatch import daemon as daemon_mod
+        branch_path = self._make_inbox(tmp_path, [
+            {"id": "abc123", "from": "@aipass", "subject": "ping",
+             "message": f"body\n{self.TOKEN}", "status": "new"}
+        ])
+        acked = []
+        monkeypatch.setattr(daemon_mod, "_auto_ack_test_email",
+                            lambda bp, be, msg: acked.append(msg["id"]) or True)
+        count = daemon_mod.scan_and_ack_test_emails(branch_path, "@drone")
+        assert count == 1
+        assert acked == ["abc123"]
+
+    def test_skips_non_test_emails(self, tmp_path, monkeypatch):
+        """Normal emails without the token are not acked."""
+        from aipass.ai_mail.apps.handlers.dispatch import daemon as daemon_mod
+        branch_path = self._make_inbox(tmp_path, [
+            {"id": "abc123", "from": "@devpulse", "subject": "task",
+             "message": "Do the thing.", "status": "new", "auto_execute": True}
+        ])
+        acked = []
+        monkeypatch.setattr(daemon_mod, "_auto_ack_test_email",
+                            lambda bp, be, msg: acked.append(msg["id"]) or True)
+        count = daemon_mod.scan_and_ack_test_emails(branch_path, "@drone")
+        assert count == 0
+        assert acked == []
+
+    def test_skips_closed_messages(self, tmp_path, monkeypatch):
+        """Closed/archived messages are not re-acked."""
+        from aipass.ai_mail.apps.handlers.dispatch import daemon as daemon_mod
+        branch_path = self._make_inbox(tmp_path, [
+            {"id": "abc123", "from": "@aipass", "subject": "ping",
+             "message": f"body\n{self.TOKEN}", "status": "closed"}
+        ])
+        acked = []
+        monkeypatch.setattr(daemon_mod, "_auto_ack_test_email",
+                            lambda bp, be, msg: acked.append(msg["id"]) or True)
+        count = daemon_mod.scan_and_ack_test_emails(branch_path, "@drone")
+        assert count == 0
+
+    def test_returns_zero_for_missing_inbox(self, tmp_path, monkeypatch):
+        """Returns 0 gracefully when inbox.json doesn't exist."""
+        from aipass.ai_mail.apps.handlers.dispatch import daemon as daemon_mod
+        branch_path = tmp_path  # no .ai_mail.local/inbox.json
+        count = daemon_mod.scan_and_ack_test_emails(branch_path, "@drone")
+        assert count == 0
+
+
+class TestPollCycleNoWakeForTestToken:
+    """poll_cycle() must not spawn agents for test-token emails."""
+
+    TOKEN = "[AIPASS-TEST — do not update memories, do not execute, reply 'ack' only]"
+
+    @pytest.fixture(autouse=True)
+    def _suppress_log(self, monkeypatch):
+        monkeypatch.setattr(
+            "aipass.ai_mail.apps.handlers.dispatch.daemon.json_handler.log_operation",
+            lambda *a, **kw: None,
+        )
+
+    def test_no_spawn_for_test_token_email(self, tmp_path, monkeypatch):
+        """A test-token auto_execute email does NOT trigger spawn_agent."""
+        from aipass.ai_mail.apps.handlers.dispatch import daemon as daemon_mod
+
+        branch_path = tmp_path / "testbranch"
+        branch_path.mkdir()
+        mail_dir = branch_path / ".ai_mail.local"
+        mail_dir.mkdir()
+        inbox = mail_dir / "inbox.json"
+        inbox.write_text(json.dumps({"messages": [
+            {"id": "t1", "from": "@aipass", "subject": "ping",
+             "message": f"Ping.\n{self.TOKEN}", "status": "new"}
+        ]}))
+
+        registry_file = tmp_path / "AIPASS_REGISTRY.json"
+        registry_file.write_text(json.dumps({
+            "branches": [{"name": "TESTBRANCH", "email": "@testbranch", "path": str(branch_path)}]
+        }))
+
+        monkeypatch.setattr(daemon_mod, "BRANCH_REGISTRY", registry_file)
+        monkeypatch.setattr(daemon_mod, "is_kill_switch_active", lambda c: False)
+        monkeypatch.setattr(daemon_mod, "_check_lock", lambda p: None)
+        monkeypatch.setattr(daemon_mod, "_is_branch_occupied", lambda p: False)
+        monkeypatch.setattr(daemon_mod, "is_protected_branch", lambda e: False)
+
+        spawned = []
+        monkeypatch.setattr(daemon_mod, "spawn_agent",
+                            lambda bp, be, msg, cfg, st: spawned.append(be) or True)
+
+        # Mock _auto_ack_test_email to avoid subprocess calls
+        monkeypatch.setattr(daemon_mod, "_auto_ack_test_email", lambda bp, be, msg: True)
+
+        config = {"autonomous_branches": [], "max_dispatches_per_branch_per_day": 10}
+        state = {"daily_counts": {}, "session_cycles": {}}
+
+        daemon_mod.poll_cycle(config, state)
+
+        assert spawned == [], "spawn_agent should NOT be called for test-token emails"


### PR DESCRIPTION
## Summary

- Adds `TEST_TOKEN` constant and four new functions to `daemon.py` implementing the @aipass ping protocol (DPLAN-0136 / FPLAN-0188 Phase 3.5)
- @aipass sends plain emails (not `--dispatch`) containing the exact token `[AIPASS-TEST — do not update memories, do not execute, reply 'ack' only]` to verify a branch is responsive without waking it
- `scan_and_ack_test_emails()` is called at the top of `poll_cycle()` before `check_inbox_for_dispatch()` — test emails are detected, ack'd via `drone @ai_mail email`, and closed via `drone @ai_mail close` before the dispatch scan runs, so no Claude session is ever spawned
- `_has_test_token()` is code-fence-aware (ignores token inside ``` blocks), case-sensitive, and line-anchored (strips leading/trailing whitespace per line)
- `_auto_ack_test_email()` runs drone with `cwd=branch_path` so ai_mail detects the correct sender identity (the target branch, not ai_mail itself)
- 13 new tests across `TestHasTestToken`, `TestScanAndAckTestEmails`, `TestPollCycleNoWakeForTestToken` — 347/347 suite passing
- Two bypass entries added to `bypass.json` for `tests/test_daemon.py` (architecture + encapsulation, same pattern as all other test files)

## Test plan

- [x] `python -m pytest src/aipass/ai_mail/tests/test_daemon.py -v` — 44/44 pass
- [x] `python -m pytest src/aipass/ai_mail/tests/ -v` — 347/347 pass
- [x] Token detection: exact match only, case-sensitive, code-fence exclusion, whitespace stripping
- [x] `poll_cycle()` does not call `spawn_agent` when inbox contains only test-token messages
- [x] `scan_and_ack_test_emails()` skips closed/archived messages and gracefully handles missing inbox

References: DPLAN-0136, FPLAN-0188 Phase 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)