### PR TITLE
feat(devpulse): watchdog: breadcrumb on exit + default timeout 1800s to 600s (FPLAN-0189)

### DIFF
--- a/.claude/hooks/auto_fix_diagnostics.py
+++ b/.claude/hooks/auto_fix_diagnostics.py
@@ -13,9 +13,10 @@ Key behaviors:
 - Surfaces ALL errors in additionalContext so Claude sees them
 - Smart batching per-file
 
-Version: 5.0.0
+Version: 5.1.0
 
 CHANGELOG:
+  - v5.1.0 (2026-04-19): Added ruff format --check to surface format drift.
   - v5.0.0 (2026-03-17): Replaced mcp__ide__getDiagnostics with direct pyright.
                           Added state file for PreToolUse gate integration.
                           Single-file pyright (not whole project).
@@ -99,7 +100,22 @@ def run_python_checks(file_path: str) -> list[str]:
     except Exception:
         pass
 
-    # 3. AIPass-specific pattern checks
+    # 3. Ruff format check — detect format drift
+    try:
+        result = subprocess.run(
+            ["ruff", "format", "--check", file_path],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        if result.returncode != 0:
+            errors.append(f"FORMAT: {Path(file_path).name} needs ruff format (run: ruff format {Path(file_path).name})")
+    except FileNotFoundError:
+        pass
+    except Exception:
+        pass
+
+    # 4. AIPass-specific pattern checks
     try:
         content = Path(file_path).read_text(encoding="utf-8")
         lines = content.split("\n")

--- a/.claude/hooks/subagent_stop_gate.py
+++ b/.claude/hooks/subagent_stop_gate.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+SubagentStop Gate — Checks files modified by subagents before allowing them to finish.
+
+Runs seedgo checklist + basic validation on any .py files the subagent touched.
+If violations found, blocks the stop and tells the subagent to fix them.
+
+Version: 1.0.0
+"""
+
+import json
+import sys
+import subprocess
+from pathlib import Path
+
+AIPASS_ROOT = Path.home() / "Projects" / "AIPass"
+
+
+def get_modified_py_files() -> list[str]:
+    """Get Python files modified in the working tree (unstaged + staged)."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(AIPASS_ROOT)
+        )
+        files = []
+        for line in result.stdout.strip().split("\n"):
+            line = line.strip()
+            if line.endswith(".py") and not line.startswith(".claude/"):
+                full = AIPASS_ROOT / line
+                if full.exists():
+                    files.append(str(full))
+        return files
+    except Exception:
+        return []
+
+
+def run_seedgo_checklist(file_path: str) -> list[str]:
+    """Run seedgo checklist on a single file."""
+    if "/.claude/" in file_path:
+        return []
+    try:
+        result = subprocess.run(
+            ["drone", "@seedgo", "checklist", file_path],
+            capture_output=True, text=True, timeout=15,
+            cwd=str(AIPASS_ROOT)
+        )
+        if result.returncode != 0:
+            return []
+        violations = []
+        for line in result.stdout.split("\n"):
+            line = line.strip()
+            if line.startswith("\u2717"):
+                v = line[1:].strip()
+                if v:
+                    violations.append(v)
+        return violations[:5]
+    except Exception:
+        return []
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+
+        modified = get_modified_py_files()
+        if not modified:
+            return  # Nothing to check
+
+        all_violations = {}
+        for f in modified:
+            vs = run_seedgo_checklist(f)
+            if vs:
+                name = Path(f).name
+                all_violations[name] = vs
+
+        if not all_violations:
+            return  # All clear
+
+        # Build the block reason
+        lines = ["Standards violations found in files you modified:\n"]
+        for fname, vs in all_violations.items():
+            lines.append(f"  {fname}:")
+            for v in vs:
+                lines.append(f"    - {v}")
+        lines.append("\nFix these violations before finishing.")
+
+        output = {
+            "decision": "block",
+            "reason": "\n".join(lines)
+        }
+        print(json.dumps(output))
+
+    except Exception:
+        pass  # Silent fail — don't block on errors
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aipass/devpulse/.seedgo/bypass.json
+++ b/src/aipass/devpulse/.seedgo/bypass.json
@@ -100,6 +100,11 @@
       "standard": "json_structure",
       "file": "apps/handlers/watchdog/registry.py",
       "reason": "Devpulse is a manager branch with no json_handler. Registry logs through prax system_logger. Same situation as watchdog/agent.py, timer.py, schedule.py."
+    },
+    {
+      "standard": "encapsulation",
+      "file": "tests/test_watchdog_module.py",
+      "reason": "Test file imports aipass.devpulse.apps.modules.watchdog for direct router testing (same-branch import). Encapsulation check pattern-matches on 'from aipass.*.apps.*' shape regardless of same- vs cross-branch. Inherits branch-level gap (manager branch, no apps/handlers/__init__.py inspect.stack guard)."
     }
   ],
   "notes": {

--- a/src/aipass/devpulse/apps/handlers/watchdog/agent.py
+++ b/src/aipass/devpulse/apps/handlers/watchdog/agent.py
@@ -178,14 +178,15 @@ def _classify_exit(branch_path: Path, lock_existed: bool) -> tuple[str, str, int
 
 def watch_agent(
     agent_id: str,
-    timeout_seconds: int = 1800,
+    timeout_seconds: int = 600,
     poll_interval: float = 2.0,
 ) -> dict:
     """Block until the dispatched agent at `agent_id` exits.
 
     Args:
         agent_id: Branch token like ``@drone`` (or bare ``drone``).
-        timeout_seconds: Maximum wait. Default 30 min.
+        timeout_seconds: Maximum wait. Default 10 min — catches crashes + silent-finishes
+            fast; long agent watches should pass an explicit ``--timeout``.
         poll_interval: Seconds between checks. Default 2.0.
 
     Returns:

--- a/src/aipass/devpulse/apps/modules/watchdog.py
+++ b/src/aipass/devpulse/apps/modules/watchdog.py
@@ -32,7 +32,7 @@ from aipass.prax.apps.modules.logger import system_logger as logger
 from aipass.cli.apps.modules import console, error, warning
 
 _VALID_SUBCOMMANDS = ["agent", "timer", "schedule", "status", "cancel", "list"]
-_DEFAULT_AGENT_TIMEOUT = 1800
+_DEFAULT_AGENT_TIMEOUT = 600
 _NOT_IMPLEMENTED_MSG = "{sub} is not yet implemented in this phase — see FPLAN-0186 (Phase {phase})"
 # Phase 4 wired cancel + list for real. Left the map so future deferrals can reuse the shape.
 _PHASE_BY_SUB: dict[str, int] = {}
@@ -353,6 +353,9 @@ def _handle_agent(sub_args: List[str]) -> bool:
     reason = result.get("reason", "")
     elapsed = result.get("elapsed", 0)
     console.print(f"[bold]watchdog agent[/bold] {agent_id} -> state={state} elapsed={elapsed}s reason={reason}")
+    console.print(
+        f'watchdog: {agent_id} stopped (state={state}). Next: drone @ai_mail dispatch {agent_id} "check in" "..."'
+    )
     return True
 
 

--- a/src/aipass/devpulse/tests/test_watchdog_module.py
+++ b/src/aipass/devpulse/tests/test_watchdog_module.py
@@ -279,3 +279,50 @@ def test_agent_subcommand_invalid_timeout(capsys):
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert "invalid" in combined.lower() or "--timeout" in combined.lower()
+
+
+def test_agent_subcommand_default_timeout_is_600():
+    """Without an explicit --timeout, the module passes 600s (FPLAN-0189)."""
+    captured_args = {}
+
+    def fake_watch_agent(agent_id, timeout_seconds=9999):
+        """Fake watcher — records the timeout the module passed in."""
+        captured_args["timeout"] = timeout_seconds
+        return {
+            "woke": True,
+            "reason": "fake",
+            "elapsed": 1,
+            "agent_state": "completed",
+            "exit_code": 0,
+            "agent_id": agent_id,
+        }
+
+    fake_module = type(sys)("fake_agent_mod")
+    fake_module.watch_agent = fake_watch_agent
+
+    with patch("importlib.import_module", return_value=fake_module):
+        wd_mod.handle_command("watchdog", ["agent", "@flow"])
+
+    assert captured_args["timeout"] == 600
+
+
+def test_agent_subcommand_emits_next_action_breadcrumb(capsys):
+    """On exit, the CLI prints a 'Next: drone @ai_mail dispatch' breadcrumb (FPLAN-0189)."""
+    fake_result = {
+        "woke": True,
+        "reason": "fake clean exit",
+        "elapsed": 5,
+        "agent_state": "completed",
+        "exit_code": 0,
+        "agent_id": "@drone",
+    }
+    fake_module = type(sys)("fake_agent_mod")
+    fake_module.watch_agent = lambda agent_id, timeout_seconds=600: fake_result
+
+    with patch("importlib.import_module", return_value=fake_module):
+        wd_mod.handle_command("watchdog", ["agent", "@drone"])
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Next: drone @ai_mail dispatch @drone" in combined
+    assert "state=completed" in combined


### PR DESCRIPTION
## Summary

Watchdog patch from FPLAN-0189 (devpulse owns):
- `src/aipass/devpulse/apps/modules/watchdog.py` — breadcrumb line on agent exit, default timeout 1800s → 600s
- `src/aipass/devpulse/apps/handlers/watchdog/agent.py` — default timeout_seconds 1800 → 600
- `src/aipass/devpulse/tests/test_watchdog_module.py` — 2 new tests (default=600, breadcrumb output)
- `src/aipass/devpulse/.seedgo/bypass.json` — justified encapsulation bypass for the test file (same-branch import, manager-branch gap)

## ⚠️ Night-shift contamination — heads up

This commit (`d226fd2`) also includes @seedgo's DPLAN-0131 Phase 1a work:
- `.claude/hooks/auto_fix_diagnostics.py` — ruff format --check added (v5.1.0)
- `.claude/hooks/subagent_stop_gate.py` — DevPass-style SubagentStop gate (100 lines, NEW)

**Root cause:** concurrent `drone @git pr` calls during the S96 night shift. @seedgo had pre-staged `.claude/hooks/*` in the git index before running their own `drone @git pr`. When my drone @git pr ran `git add src/aipass/devpulse/` + `git commit`, the commit swept ALL staged index entries (git commit doesn't distinguish what `git add` put there vs what was pre-staged). Seedgo's `citizen/seedgo-hooks` branch ended up with 0 unique commits — their work landed in mine.

**Fix for future:** `pr_handler.py` should `git reset` (unstage all) at start before its scoped `git add`. File as friction note for @drone.

Seedgo's changes are CORRECT and intended — they're the DPLAN-0131 Phase 1a completion. Just not cleanly separated from the watchdog patch. Reviewing both together is fine; PR #350 sits on top of this and will cleanly add ai_mail's auto-spawn after this merges.

## Test plan
- [x] 24 watchdog tests pass (`tests/test_watchdog_module.py` + `tests/test_watchdog_agent.py`)
- [x] 27/27 seedgo standards pass on watchdog files
- [x] ruff check + format both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)