### PR TITLE
feat(system): chore: gitignore src/aipass/aipass/ — S95 under-construction branch, locks in intended working-tree state that was never committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,11 @@ docs.local/
 .claude/hooks/__pycache__/
 .claude/hooks/.last_diagnostics_file
 .claude/worktrees/
+
+# @aipass citizen — under construction, whole branch gitignored until ready.
+# Nothing in the public system depends on aipass, so this can live invisibly
+# while we build + test. Remove this block when ready to reveal (DPLAN-0136).
+src/aipass/aipass/
 # **/.claude/settings.local.json — UNIGNORED: deny rules are system config that must travel with PRs
 
 # Disabled files (AIPass convention: rename with (disabled) instead of delete)


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- chore: gitignore src/aipass/aipass/ — S95 under-construction branch, locks in intended working-tree state that was never committed
- 1 commit(s) ahead of origin/main
