### PR TITLE
feat(system): chore(deny): add git checkout to Bash deny list — enforces drone-only git policy via permission gate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,7 @@
       "EnterPlanMode",
       "Bash(git add -f*)",
       "Bash(git add --force*)",
+      "Bash(git checkout*)",
       "Read(/home/patrick/Patrick-Personal/**)",
       "Edit(/home/patrick/Patrick-Personal/**)",
       "Write(/home/patrick/Patrick-Personal/**)",


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- chore(deny): add git checkout to Bash deny list — enforces drone-only git policy via permission gate
- 1 commit(s) ahead of origin/main
