### PR TITLE
feat(system): docs(policy): propagate git-checkout deny rule through global prompt + devpulse prompt + drone @git --help

### DIFF
--- a/.aipass/aipass_global_prompt.md
+++ b/.aipass/aipass_global_prompt.md
@@ -158,9 +158,11 @@ Always work on main. Edit files in your branch directory on the main branch. Whe
 
 `drone @git pr` does everything atomically: acquires a lock (so no other branch can PR simultaneously), creates a feature branch, stages only your files, commits with your Co-Authored-By signature, pushes, creates the PR on GitHub, returns to main, releases the lock.
 
-Blocked for you: `git checkout -b`, `git commit`, `git push`, `gh pr create`. Only devpulse and drone have raw git access.
+**Blocked system-wide via `.claude/settings.json` permission gate:** `git checkout*` (any form — switch, discard, new branch), `git add -f*`, `git add --force*`. These are denied for every agent including devpulse. Use `drone @git sync` to switch to main, `drone @git fix` to recover from broken states.
 
-Allowed read-only: `git status`, `git diff`, `git log`.
+**Culturally blocked (no permission gate yet, still don't use):** `git commit`, `git push`, `gh pr create`. Go through drone.
+
+**Allowed read-only:** `git status`, `git diff`, `git log`, `git stash` (safe transient save).
 
 Never merge. Only devpulse or the user merges PRs. If your PR gets feedback, fix it and run `drone @git pr` again.
 

--- a/src/aipass/devpulse/.aipass/aipass_local_prompt.md
+++ b/src/aipass/devpulse/.aipass/aipass_local_prompt.md
@@ -34,7 +34,7 @@ When a task belongs to a specialist's DOMAIN, ask them. You can still investigat
 
 ## Git Workflow — Drone Only
 
-Never use raw git commands (git commit, git push, git checkout -b, gh pr create). Every time raw git is used, it causes divergence, rebase conflicts, and wasted time fixing the mess. Drone handles everything correctly.
+Never use raw git commands (git commit, git push, git checkout anything, gh pr create). `Bash(git checkout*)` and `Bash(git add -f*)` are denied system-wide in `.claude/settings.json`. Every time raw git is used, it causes divergence, rebase conflicts, and wasted time fixing the mess. Drone handles everything correctly.
 
 ```
 drone @git system-pr "description"   # System-wide PR (devpulse only) — commit, branch, push, PR, back to main

--- a/src/aipass/drone/apps/modules/git_module.py
+++ b/src/aipass/drone/apps/modules/git_module.py
@@ -444,6 +444,11 @@ def get_help(command: str | None = None) -> str:
         "  sync                   Checkout main and pull\n"
         "  lock                   Check lock status\n"
         "  unlock --force         Force-release the PR lock\n"
+        "\n"
+        "Policy: raw git commands are blocked for agents via .claude/settings.json:\n"
+        "  - git checkout* (any form) — use `drone @git sync` instead\n"
+        "  - git add -f* / --force*  — use scoped `drone @git pr` instead\n"
+        "Culturally also avoid: raw git commit/push, gh pr create. Go through drone.\n"
     )
 
 


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- docs(policy): propagate git-checkout deny rule through global prompt + devpulse prompt + drone @git --help
- 1 commit(s) ahead of origin/main
