### PR TITLE
fix(memory/tests): repair test_json_handler harness — KeyError on sys.modules (#360 finding A2)

### DIFF
--- a/src/aipass/memory/.seedgo/bypass.json
+++ b/src/aipass/memory/.seedgo/bypass.json
@@ -585,6 +585,16 @@
       "file": "tests/test_vector.py",
       "standard": "meta",
       "reason": "Test file — META block present at lines 1-7; hook false-positive on test file format."
+    },
+    {
+      "file": "tests/test_json_handler.py",
+      "standard": "architecture",
+      "reason": "Test file — lives in tests/ by design, not in 3-layer apps/ structure."
+    },
+    {
+      "file": "tests/test_json_handler.py",
+      "standard": "meta",
+      "reason": "Test file — META block present at lines 1-7; hook false-positive on test file format."
     }
   ],
   "notes": {

--- a/src/aipass/memory/tests/test_json_handler.py
+++ b/src/aipass/memory/tests/test_json_handler.py
@@ -41,42 +41,21 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _fresh_json_handler(monkeypatch):
-    """Ensure json_handler module is freshly imported each test.
-
-    The conftest autouse fixture mocks the json package. We need to
-    restore the real module for direct testing via importlib.reload.
-    """
-    saved_json_pkg = sys.modules.pop("aipass.memory.apps.handlers.json", None)
+    """Ensure json_handler module is freshly imported each test."""
+    sys.modules.pop("aipass.memory.apps.handlers.json", None)
     sys.modules.pop("aipass.memory.apps.handlers.json.json_handler", None)
     sys.modules.pop("aipass.memory.apps.handlers.json.memory_files", None)
-
-    try:
-        pass  # noqa: F811
-    except Exception:
-        if saved_json_pkg is not None:
-            sys.modules["aipass.memory.apps.handlers.json"] = saved_json_pkg
-
-    jh_key = "aipass.memory.apps.handlers.json.json_handler"
-    existing = sys.modules.get(jh_key)
-    if existing is not None:
-        importlib.reload(existing)
-    else:
-        sys.modules.pop(jh_key, None)
-
     yield
 
 
 def _get_json_handler():
     """Import and return the json_handler module."""
-    return sys.modules["aipass.memory.apps.handlers.json.json_handler"]
+    return importlib.import_module("aipass.memory.apps.handlers.json.json_handler")
 
 
 def _get_memory_files():
     """Import and return the memory_files module."""
-    mf_key = "aipass.memory.apps.handlers.json.memory_files"
-    if mf_key not in sys.modules:
-        pass  # noqa: F811
-    return sys.modules[mf_key]
+    return importlib.import_module("aipass.memory.apps.handlers.json.memory_files")
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- `_get_json_handler()` was calling `sys.modules["aipass.memory.apps.handlers.json.json_handler"]` — but `_fresh_json_handler` fixture had just popped that key, so every test raised `KeyError`
- Fix: replace `sys.modules[]` lookup with `importlib.import_module()` in both `_get_json_handler()` and `_get_memory_files()`
- Cleaned up dead code in `_fresh_json_handler` fixture (the reload/re-pop block that could never execute after the earlier pop)
- Added 2 bypass entries in `bypass.json` for `test_json_handler.py` seedgo false-positives (architecture/meta — same pattern as `test_vector.py`)

## Test plan
- [ ] `pytest src/aipass/memory/tests/test_json_handler.py` — 30 passed (was 27 failed + 3 passed)
- [ ] Full suite: 450 passed, 1 skipped — no regressions

Closes #360 finding A2

🤖 Generated with [Claude Code](https://claude.com/claude-code)