### PR TITLE
fix(drone): resolve tempdir fixture in registry_handler tests — unblock Mac (issue #360 finding A1)

### DIFF
--- a/src/aipass/drone/tests/test_registry_handler.py
+++ b/src/aipass/drone/tests/test_registry_handler.py
@@ -43,7 +43,7 @@ from aipass.drone.apps.handlers.exceptions import (
 @pytest.fixture
 def registry_dir() -> Generator[Path, None, None]:
     """Isolated temp directory for registry tests; cleaned up after."""
-    d = Path(tempfile.mkdtemp(prefix="reg_test_"))
+    d = Path(tempfile.mkdtemp(prefix="reg_test_")).resolve()
     yield d
     shutil.rmtree(d, ignore_errors=True)
 


### PR DESCRIPTION
## Summary

One-line test fixture fix. `src/aipass/drone/tests/test_registry_handler.py:46` — add `.resolve()` to the `registry_dir` fixture so both sides of path comparisons use the canonical form on every OS. Unblocks two Mac-specific test failures surfaced during issue #360's Mac install verification.

## Context

Issue: #360 finding A1 (the Mac fresh-install session that validated your PRs #361 + #362).

Two tests failed on macOS 12.7.6 Intel:
- `TestLoadRegistry::test_relative_paths_resolved`
- `TestFindRegistry::test_find_registry_from_child_dir`

Root cause is macOS-specific but not obvious: `/var/folders` is a symlink to `/private/var/folders`. `tempfile.mkdtemp()` returns the unresolved form. Production code (PR #361 / commit 8a5fbf6) correctly calls `Path.resolve()` which follows the symlink. The fixture's `registry_dir` stored the unresolved path, so string/path comparisons diverged: one side `/var/folders/...`, other side `/private/var/folders/...`.

## The fix

```diff
-    d = Path(tempfile.mkdtemp(prefix="reg_test_"))
+    d = Path(tempfile.mkdtemp(prefix="reg_test_")).resolve()
```

## Platform behavior

| Platform | `.resolve()` effect | Test result before | Test result after |
|---|---|---|---|
| Linux | no-op (no symlink, already canonical) | ✅ passing | ✅ still passing |
| macOS | follows `/var/folders → /private/var/folders` | ❌ 2 failing | ✅ now passing |
| Windows | normalizes short-path → long-path, consistent with production code | ✅ passing | ✅ still passing |

## Verified locally

macOS 12.7.6 Intel, Python 3.11.15 (via `uv`), venv from `setup.sh`:

```
$ .venv/bin/pytest -q src/aipass/drone/tests/test_registry_handler.py
33 passed in 0.41s
```

Before the fix: 31 passed, 2 failed (`test_relative_paths_resolved` + `test_find_registry_from_child_dir`).

## Follow-up (NOT this PR)

Recommended cleanup: migrate `registry_dir` fixture to pytest's built-in `tmp_path` fixture, which already returns a pre-resolved `Path`. That removes the class of fixture bug entirely across the test suite — no individual test needs to remember `.resolve()`. Flagging for a future test-hygiene pass.

## Test plan

- [x] Run `pytest -q src/aipass/drone/tests/test_registry_handler.py` on macOS → 33/33 pass
- [ ] CI confirms Linux still green (one-line change, should be a no-op on Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)