### PR TITLE
feat(system): fix(dispatch): switch default model from sonnet to opus 4.6 — all dispatched agents now run on Opus 4.6 (DPLAN-0141 Phase 1)

### DIFF
--- a/src/aipass/ai_mail/apps/handlers/dispatch/wake.py
+++ b/src/aipass/ai_mail/apps/handlers/dispatch/wake.py
@@ -69,7 +69,7 @@ MODEL_MAP = {
     "opus": "claude-opus-4-6",
     "haiku": "claude-haiku-4-5-20251001",
 }
-DEFAULT_MODEL = "sonnet"
+DEFAULT_MODEL = "opus"
 
 # Branches that cannot be woken manually by cross-branch drone commands.
 # Dispatch-send path (dispatch.py._orchestrate_dispatch_send) bypasses this check.
@@ -572,7 +572,7 @@ if __name__ == "__main__":
         print("  --fresh          Start fresh session (claude -p) instead of resuming (claude -c -p)")
         print("  --auto           Respect autonomous_pause (used by daemon). Manual wake ignores it.")
         print("  --sender @branch Set return-to-sender for bounce emails (default: @devpulse)")
-        print("  --model NAME     Model to use: sonnet (default), opus, haiku, or full model ID")
+        print("  --model NAME     Model to use: opus (default), sonnet, haiku, or full model ID")
         print()
         print("Output: Step-by-step status of the dispatch pipeline:")
         print("  ✅ resolve → @branch found at /path/to/branch")

--- a/src/aipass/ai_mail/apps/modules/dispatch.py
+++ b/src/aipass/ai_mail/apps/modules/dispatch.py
@@ -49,8 +49,8 @@ WAKE ONLY:
   drone wake @branch                                         # Shortcut via drone
 
 MODEL OPTIONS:
-  --model sonnet   Claude Sonnet 4.6 (default — cost-effective for most tasks)
-  --model opus     Claude Opus 4.6 (complex tasks needing deeper reasoning)
+  --model opus     Claude Opus 4.6 (default — full reasoning for all tasks)
+  --model sonnet   Claude Sonnet 4.6 (cost-effective for lighter tasks)
   --model haiku    Claude Haiku 4.5 (fastest, simplest tasks)
 
 DAEMON:

--- a/src/aipass/ai_mail/tests/test_wake.py
+++ b/src/aipass/ai_mail/tests/test_wake.py
@@ -454,9 +454,9 @@ def test_model_map_has_expected_entries():
     assert "claude-opus-4-6" in MODEL_MAP["opus"]
 
 
-def test_default_model_is_sonnet():
-    """Default model should be sonnet."""
-    assert DEFAULT_MODEL == "sonnet"
+def test_default_model_is_opus():
+    """Default model should be opus."""
+    assert DEFAULT_MODEL == "opus"
 
 
 def test_model_map_values_are_full_ids():


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- fix(dispatch): switch default model from sonnet to opus 4.6 — all dispatched agents now run on Opus 4.6 (DPLAN-0141 Phase 1)
- 1 commit(s) ahead of origin/main
