### PR TITLE
docs(seedgo): comprehensive README update

### DIFF
--- a/src/aipass/ai_mail/README.md
+++ b/src/aipass/ai_mail/README.md
@@ -9,16 +9,35 @@
 
 ---
 
-**Status:** Operational. Core email workflow (send/inbox/reply/close), dispatch system (with startup timeout + auto-retry), daemon, desktop notifications all working. Seedgo 99%.
+**Status:** Operational | **Seedgo:** 100% (34/34) | **Tests:** 355 pass | **Battle Tested:** S62
 
-## Commands / Usage
+## Commands
 
 ```bash
+# Dispatch (send + wake in one step)
 drone @ai_mail dispatch @target "Subject" "Body"          # Send dispatch email + wake
-drone @ai_mail dispatch @target "Subject" "Body" --fresh  # Send + fresh wake
-drone @ai_mail email @target "Subject" "Body"             # Send email (no wake)
+drone @ai_mail dispatch @target "Subject" "Body" --fresh  # Send + fresh wake (new session)
 drone @ai_mail dispatch wake @target                      # Wake only (no email)
-drone @ai_mail inbox                                      # Check inbox
+
+# Send mail (no wake)
+drone @ai_mail email @target "Subject" "Body"             # Send to one branch
+drone @ai_mail email @all "Subject" "Body"                # Broadcast to all branches
+drone @ai_mail email @target "Subj" "Body" --from @spawn  # Explicit sender override
+
+# Read mail
+drone @ai_mail inbox                                      # List all emails (new + opened)
+drone @ai_mail view <id>                                  # View email (marks as opened)
+drone @ai_mail view latest                                # View most recent email
+
+# Resolve mail
+drone @ai_mail reply <id> "message"                       # Reply + close + archive original
+drone @ai_mail close <id>                                 # Close single email
+drone @ai_mail close <id1> <id2> <id3>                    # Close multiple emails
+drone @ai_mail close all                                  # Close all emails
+
+# Other
+drone @ai_mail sent                                       # View sent messages
+drone @ai_mail contacts                                   # List all known branches
 drone @ai_mail --help                                     # Full help
 ```
 
@@ -34,16 +53,55 @@ new → opened → closed
 - **opened** — Viewed by recipient, awaiting action
 - **closed** — Replied or dismissed, archived automatically
 
+Each branch's mailbox lives at `<branch_path>/.ai_mail.local/inbox.json`. Sent copies go to `.ai_mail.local/sent/`. File locking (`fcntl`/`msvcrt`) protects concurrent inbox writes.
+
 ## Dispatch System
 
-The `dispatch` command sends an email and wakes the target branch in one step. A polling daemon can also watch inboxes and spawn agents for `auto_execute` dispatch emails automatically.
+The `dispatch` command sends an email and wakes the target branch in one step. Dispatch emails carry `auto_execute: true` and a task header, signaling the target agent to process them as work items.
 
-- Agents are ephemeral (wake, do work, exit)
-- Safety limits: max turns per wake, max dispatches per branch per day
-- PID-based locking prevents concurrent agents per branch
-- Startup health check: monitors JSONL session files for 90s, kills if no activity
-- Auto-retry: 3 strikes (resume, resume, fresh) before bounce
-- Failed agents trigger bounce emails back to sender
+### Wake Pipeline
+
+1. `dispatch.py` orchestrates: send email via `send_to_single()`, then wake via `wake_branch()`
+2. `wake.py` resolves the branch from the registry, finds the `claude` binary, spawns a subprocess
+3. `dispatch_monitor.py` wraps the claude process with safety features:
+   - **Startup health check** — monitors JSONL session files for 90s, kills if no activity
+   - **Auto-retry** — 3 strikes: attempt 1+2 resume, attempt 3 fresh (new session)
+   - **Bounce email** — on final failure, sends error report back to sender
+   - **Lock cleanup** — removes `.dispatch.lock` when agent exits
+4. After wake, `_spawn_watchdog()` auto-launches `drone @devpulse watchdog agent @target` as a detached background process
+
+### Safety Limits
+
+- PID-based locking prevents concurrent agents per branch (`.dispatch.lock`)
+- Max turns per wake, max dispatches per branch per day
+- `WAKE_BLOCKLIST` protects `@devpulse` from cross-branch manual wakes
+- `dispatch_monitor.py` strips `AIPASS_CALLER_*` env vars to prevent parent context leaking into agent identity
+- `AIPASS_BRANCH_NAME` env var set in spawn_env for CWD-independent identity
+
+### Daemon
+
+The polling daemon (`daemon.py`) watches inboxes for `auto_execute` dispatch emails and spawns agents automatically. It also runs the AIPASS-TEST token protocol: `scan_and_ack_test_emails()` intercepts ping-test messages and auto-replies with "ack" before dispatch processing.
+
+## Sender Identity
+
+Branch identity detection follows a priority chain in `detect_branch_from_pwd()`:
+
+1. `AIPASS_CALLER_BRANCH` env var (set by drone router from passport or `AIPASS_BRANCH_NAME`)
+2. Contacts address book lookup (fastest path for registered branches)
+3. Registry lookup by name
+4. `AIPASS_CALLER_CWD` / `Path.cwd()` walk-up to find `.trinity/passport.json`
+5. Registry lookup by path
+
+If all fail, detection returns `None` and the operation fails loudly. Wrong identity is worse than no identity.
+
+The `--from @branch` flag on send/email commands provides an explicit sender override for callers outside branch directories.
+
+## Cross-Project Email
+
+External projects (outside the AIPass repo) can send to AIPass branches. On delivery, `delivery.py` stores a `reply_path` on the message (the sender's `inbox.json` path, resolved from `AIPASS_CALLER_CWD`). Replies use `_deliver_via_reply_path()` to write directly to the external inbox without needing registry lookup.
+
+The contacts system (`contacts.py`) maintains an address book at `.ai_mail.local/contacts.json`, auto-registering branches on every send/receive. This enables fast sender detection for known branches without CWD walking or registry lookups.
+
 ## Architecture
 
 Follows the standard AIPass 3-layer pattern:
@@ -51,20 +109,65 @@ Follows the standard AIPass 3-layer pattern:
 ```
 ai_mail/
 ├── apps/
-│   ├── ai_mail.py          # Entry point (auto-discovers modules)
+│   ├── ai_mail.py              # Entry point (auto-discovers modules)
 │   ├── modules/
-│   │   ├── email.py        # Inbox, view, reply, close, contacts, routing
-│   │   ├── email_send.py   # Send orchestration (direct, interactive, broadcast)
-│   │   ├── dispatch.py     # Dispatch status, daemon, wake
+│   │   ├── email.py            # Inbox, view, reply, close, contacts, routing
+│   │   ├── email_send.py       # Send orchestration (direct, interactive, broadcast)
+│   │   └── dispatch.py         # Dispatch send+wake, status, daemon control
 │   └── handlers/
-│       ├── email/           # Delivery, formatting, inbox ops, purge, reply
-│       ├── dispatch/        # Daemon, wake, dispatch_monitor, status, test_token
-│       ├── registry/        # Branch registry read
-│       ├── users/           # Branch detection, user lookup
-│       ├── json_utils/      # JSON I/O helpers (load_json, save_json)
-│       ├── paths.py         # Shared find_repo_root() utility
-│       ├── notify.py        # Desktop notifications (dbus)
-│       └── central_writer.py # Central inbox stats aggregation
+│       ├── email/
+│       │   ├── delivery.py     # Core delivery pipeline (write to recipient inbox)
+│       │   ├── send.py         # Sender resolution + send helpers
+│       │   ├── send_args.py    # Argument parsing for send command
+│       │   ├── inbox_ops.py    # Inbox loading + v1→v2 migration
+│       │   ├── inbox_cleanup.py # Mark opened/closed + archive
+│       │   ├── inbox_lock.py   # File locking (fcntl/msvcrt cross-platform)
+│       │   ├── inbox_resolve.py # Resolve inbox path from args or caller
+│       │   ├── reply.py        # Reply + auto-close original
+│       │   ├── close_ops.py    # Batch close operations
+│       │   ├── contacts.py     # Address book for branch routing
+│       │   ├── create.py       # Email file creation (sent/ folder)
+│       │   ├── format.py       # Display formatting
+│       │   ├── header.py       # Dispatch header injection
+│       │   ├── footer.py       # Email footer
+│       │   ├── purge.py        # Auto-purge sent/deleted folders
+│       │   ├── error_dispatch.py # Error reporting via email
+│       │   └── dashboard_sync.py # Dashboard integration
+│       ├── dispatch/
+│       │   ├── daemon.py       # Polls inboxes, spawns agents for dispatch emails
+│       │   ├── wake.py         # Wakes branches via claude subprocess
+│       │   ├── dispatch_monitor.py # Wraps claude process (bounce + lock cleanup)
+│       │   ├── status.py       # Dispatch log I/O
+│       │   └── test_token.py   # AIPASS-TEST ping protocol (auto-ack)
+│       ├── registry/
+│       │   └── read.py         # Registry reading + get_all_branches()
+│       ├── users/
+│       │   ├── branch_detection.py # CWD/env-based branch identity detection
+│       │   └── user.py         # Current user detection (get_current_user)
+│       ├── json_utils/
+│       │   └── json_handler.py # Auto-creating JSON system
+│       ├── paths.py            # Shared find_repo_root() utility
+│       ├── notify.py           # Desktop notifications (dbus direct)
+│       └── central_writer.py   # Central inbox stats aggregation
+└── tests/                      # 355 tests across 16 test files
+    ├── conftest.py             # Shared fixtures (mock_logger, mock_json_handler)
+    ├── test_daemon.py          # Daemon config, state, kill switch, dispatch check
+    ├── test_dispatch_monitor.py # Monitor safety features, env stripping
+    ├── test_dispatch_status.py # Log I/O, age calculation
+    ├── test_dispatch_watchdog.py # Watchdog auto-spawn
+    ├── test_wake.py            # Branch resolution, PID checks, lock files
+    ├── test_wake_blocklist.py  # Wake protection for @devpulse
+    ├── test_delivery.py        # Inbox migration, private branches, pipeline
+    ├── test_send_identity.py   # Sender identity chain (36 tests)
+    ├── test_user_paths.py      # Mailbox path resolution (13 tests)
+    ├── test_contacts.py        # Address book operations
+    ├── test_inbox_ops.py       # Inbox loading + migration
+    ├── test_registry_read.py   # Registry parsing + branch lookup
+    ├── test_central_writer.py  # Central stats aggregation
+    ├── test_cli_routing.py     # CLI routing + help/version
+    ├── test_json_handler.py    # JSON I/O helpers
+    ├── test_notify.py          # Desktop notification dbus calls
+    └── test_paths.py           # find_repo_root() utility
 ```
 
 ## Integration Points
@@ -73,16 +176,22 @@ ai_mail/
 - `aipass.prax` — Logging via `system_logger`
 - `aipass.cli` — Console output and display formatting
 - `aipass.drone` — Command routing and `@branch` resolution
-- Python stdlib (`pathlib`, `json`, `argparse`, `importlib`)
+- `aipass.trigger` — `trigger.fire()` for `email_dispatched` events
+- Python stdlib (`pathlib`, `json`, `argparse`, `importlib`, `subprocess`, `fcntl`)
 
 ### Provides To
-- All modules — inter-branch messaging (send/receive/reply/close)
-- Dispatch system — autonomous task execution via `--dispatch` flag
-- Branch contacts — address book for `@branch` routing
+- **All branches** — inter-branch messaging (send/receive/reply/close)
+- **Dispatch system** — autonomous task execution via `auto_execute` emails
+- **Branch contacts** — address book for `@branch` routing
+- **trigger branch** — `deliver_email_to_branch()` imported directly for event-driven delivery
+- **Desktop** — dbus notifications for delivery, wake, completion events
+
+## Known Issues
+
+- **DPLAN-0138**: Inbox backdoor audit identified 2 write path classes — ad-hoc direct writes (detectable by non-UUID ID format) and `_deliver_via_reply_path()` bypass (no lock, no notification). Fix pending.
+- **Caller detection**: `BRANCH DETECTION FAILED` when callers don't set `AIPASS_CALLER_BRANCH` (low severity, caller-side fix — use `--from` flag)
+- **Cross-branch writes**: ai_mail not in trusted cross-writers list for `system-pr`
 
 ---
 
-*Last Updated: 2026-04-07*
-
----
 [← Back to AIPass](../../../README.md)

--- a/src/aipass/cli/README.md
+++ b/src/aipass/cli/README.md
@@ -2,13 +2,16 @@
 
 # CLI
 
-**Purpose:** Display and output formatting service for AIPass modules. Provides consistent terminal output — headers, success/error/warning messages, section breaks, and operation templates — so every module looks the same without duplicating Rich formatting code.
+**Purpose:** Display and output formatting service for all AIPass branches, plus the `aipass init` project bootstrap command. Provides consistent terminal output — headers, success/error/warning messages, section breaks, and operation templates — so every branch looks the same without duplicating Rich formatting code.
 **Module:** `aipass.cli`
-**Seedgo:** 100%
-**Tests:** 60+ passing (6 files, 5/5 modules covered)
+**Version:** 2.0.0
+**Seedgo:** 100% (34/34 standards)
+**Tests:** 171 passing (6 files, 5/5 modules covered)
 **Last Updated:** 2026-04-22
 
 ## Usage
+
+### Display Functions
 
 ```python
 from aipass.cli import header, success, error, warning, section
@@ -27,13 +30,13 @@ from aipass.cli import operation_start, operation_complete
 
 operation_start("Processing", count=10)
 # ... do work ...
-operation_complete(created=5, skipped=3, failed=0)
+operation_complete(created=5, skipped=3, failed=0, time="1.2s")
 ```
 
 ### Fatal (exit on error)
 
 ```python
-from aipass.cli.apps.modules.display import fatal
+from aipass.cli import fatal
 
 fatal("Config file missing", suggestion="Run aipass init first")
 # Prints error message + suggestion, then calls sys.exit(1)
@@ -47,55 +50,48 @@ from aipass.cli import console
 console.print("[bold cyan]Custom Rich output[/bold cyan]")
 ```
 
-## Architecture
+## Public API
 
-```
-cli/
-├── apps/
-│   ├── cli.py                  # Entry point (main, discover_modules, route_command)
-│   ├── modules/
-│   │   ├── display.py          # header, success, error, warning, fatal, section
-│   │   ├── templates.py        # operation_start, operation_complete
-│   │   └── init_project.py     # aipass init command routing
-│   └── handlers/
-│       ├── init/               # Project bootstrap logic
-│       │   ├── bootstrap.py
-│       │   └── scaffold_content.py
-│       ├── json/               # JSON file management
-│       │   └── json_handler.py
-│       └── templates/          # Empty — placeholder from scaffold
-├── cli_json/                   # Auto-created JSON output (three-file pattern)
-├── dropbox/                    # Inbound file drop
-├── logs/                       # Branch-level logs
-├── tests/                      # 161 tests across 6 files
-│   ├── test_bootstrap.py       # bootstrap.py handler tests
-│   ├── test_json_handler.py    # json_handler tests
-│   ├── test_display.py         # display module tests
-│   ├── test_templates.py       # templates module tests
-│   ├── test_init_project.py    # init_project module tests
-│   └── test_integration.py     # main() flow + entry point tests
-└── .archive/                   # Archived stubs (extensions/, json_templates/)
-```
+All display functions are importable from the top-level package or `apps/modules/`:
 
-- `apps/modules/` — Public API. Import from here.
-- `apps/handlers/` — Internal implementation. Don't import directly.
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `header()` | `header(title, details=None)` | Bordered section header with optional key-value pairs |
+| `success()` | `success(message, **kwargs)` | Green checkmark message with metadata |
+| `error()` | `error(message, suggestion=None)` | Red error with optional suggestion |
+| `warning()` | `warning(message, details=None)` | Yellow warning with optional details |
+| `fatal()` | `fatal(message, suggestion=None)` | Error + `sys.exit(1)` for unrecoverable failures |
+| `section()` | `section(title)` | Visual section separator with title |
+| `operation_start()` | `operation_start(operation, **details)` | Standard operation begin header |
+| `operation_complete()` | `operation_complete(**summary)` | Completion summary with optional timing |
+| `console` | Rich Console instance | Standard output console |
+| `err_console` | Rich Console instance | Stderr console |
+
+Import paths (all equivalent):
+```python
+from aipass.cli import header                              # Top-level re-export
+from aipass.cli.apps.modules import header                 # Module-level
+from aipass.cli.apps.modules.display import header         # Direct
+```
 
 ## Commands
 
 ```bash
 # Via drone
-drone @cli --help                        # Show services and Rich formatting showcase
-drone @cli --version                     # Show version
-drone @cli                               # Show discovered modules (introspection)
+drone @cli --help                        # Services + Rich formatting showcase
+drone @cli --version                     # Version (v2.0.0)
+drone @cli                               # Module discovery (introspection)
 drone @cli aipass                        # Show aipass subcommands
 drone @cli aipass init                   # Bootstrap AIPass project in current dir
 drone @cli aipass init /path             # Bootstrap in target directory
 drone @cli aipass init /path MyProject   # Bootstrap with custom name
-drone @cli aipass init agent <name>       # Create agent in project (routes to spawn)
+drone @cli aipass init update            # Re-sync managed scaffold files
+drone @cli aipass init update /path      # Re-sync in target directory
+drone @cli aipass init agent <name>      # Create agent (routes to spawn)
 drone @cli aipass init --help            # Detailed init usage
-drone @cli display                       # Display module introspection
+drone @cli display                       # Display module info
 drone @cli display demo                  # Run display function showcase
-drone @cli templates                     # Templates module introspection
+drone @cli templates                     # Templates module info
 drone @cli templates demo                # Run templates function showcase
 
 # Standalone (no drone required)
@@ -104,20 +100,104 @@ python -m aipass.cli aipass init /path   # Bootstrap directly
 aipass --help                            # Via console_scripts entry point
 ```
 
----
+## aipass init
+
+Bootstraps a new AIPass project with 21 items (when AIPASS_HOME is detected):
+
+| Category | Items Created |
+|----------|---------------|
+| Identity | `*_REGISTRY.json` |
+| Prompts | `.aipass/aipass_global_prompt.md`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` |
+| Docs | `README.md`, `STATUS.local.md` |
+| Config | `.claude/settings.json`, `.gitignore` |
+| Slash commands | `.claude/commands/prep.md`, `.claude/commands/memo.md` |
+| Hooks | 7 enforcement/injector hooks in `.claude/hooks/` |
+| Dirs | `hooks/`, `src/` |
+| Mail | `.ai_mail.local/inbox.json` |
+
+Settings.json wires 5 hook event types:
+- **UserPromptSubmit** (5 hooks): global prompt, local prompt, branch prompt loader, email notification, identity injector
+- **PostToolUse**: auto-fix diagnostics
+- **PreToolUse**: pre-edit gate
+- **Stop**: subagent stop gate
+- **PreCompact**: pre-compact
+
+`aipass init update` re-syncs managed files (prompts, config, hooks) without touching user-owned files (registry, README, STATUS.local.md, .gitignore, mailbox).
+
+Cross-platform: local prompt discovery uses `python3 -c` with pathlib (no bash dependency). A `setup.py` installer handles Windows + Linux + macOS.
+
+## Architecture
+
+```
+cli/
+├── __init__.py                 # Public API exports + cli_entry()
+├── __main__.py                 # python -m aipass.cli entry
+├── apps/
+│   ├── cli.py                  # Entry point (main, discover_modules, route_command)
+│   ├── modules/                # PUBLIC — import from here
+│   │   ├── __init__.py         # Re-exports all display + template functions
+│   │   ├── display.py          # header, success, error, warning, fatal, section
+│   │   ├── templates.py        # operation_start, operation_complete
+│   │   └── init_project.py     # aipass init command routing
+│   └── handlers/               # PRIVATE — internal implementation
+│       ├── init/
+│       │   ├── bootstrap.py    # init_project(), update_project() (511 lines)
+│       │   └── scaffold_content.py  # 10 content generators (502 lines)
+│       ├── json/
+│       │   └── json_handler.py # JSON lifecycle (CRUD, validation, rotation)
+│       └── templates/          # Empty — placeholder from scaffold
+├── tests/                      # 171 tests across 6 files
+│   ├── test_bootstrap.py       # 60 tests — init/update/hooks/memo/mailbox
+│   ├── test_json_handler.py    # 35 tests — CRUD, validation, rotation
+│   ├── test_display.py         # 28 tests — all display functions + routing
+│   ├── test_templates.py       # 19 tests — operation templates + routing
+│   ├── test_init_project.py    # 14 tests — command routing, error handling
+│   └── test_integration.py     # 8 tests — main() flow, entry points
+├── cli_json/                   # Auto-created JSON (config, data, log)
+├── logs/                       # Branch-level logs
+└── .archive/                   # Archived stubs (extensions/, json_templates/)
+```
+
+**Two-tier design:**
+- `apps/modules/` — Public API. Import from here.
+- `apps/handlers/` — Internal implementation. Don't import directly.
+
+## JSON Handler
+
+Manages the three-file JSON pattern (config, data, log) for any module:
+
+```python
+from aipass.cli.apps.handlers.json import json_handler
+
+json_handler.log_operation("files_created", {"count": 12})
+data = json_handler.load_json("cli", "config")
+json_handler.save_json("cli", "data", {"key": "value"})
+json_handler.ensure_module_jsons("cli")  # Create all 3 if missing
+```
 
 ## Integration Points
 
 ### Depends On
-- `aipass.prax` — Logging via `system_logger`
-- `rich` — Rich library for terminal formatting (Table, Panel, Columns, Text)
-- Python stdlib (`sys`, `importlib`, `pathlib`)
+- `rich` — Terminal formatting (Table, Panel, Text, Console)
+- Python stdlib (`sys`, `importlib`, `pathlib`, `json`)
+
+### Cannot Import
+- `aipass.prax` — Circular dependency (prax depends on cli). Display/templates modules bypass this with documented entries in `.seedgo/bypass.json`.
 
 ### Provides To
-- All modules — display formatting (headers, success/error/warning, section breaks)
-- All modules — operation templates (`operation_start`, `operation_complete`)
-- All modules — Rich console access
-- All users — `aipass init` project bootstrap command
+- **All branches** — Display formatting (header, success, error, warning, fatal, section)
+- **All branches** — Operation templates (operation_start, operation_complete)
+- **All branches** — Rich console access
+- **All users** — `aipass init` project bootstrap + `aipass init update` refresh
+- **All users** — `aipass init agent` routing to spawn
+
+## Entry Points
+
+| Entry | Command | How |
+|-------|---------|-----|
+| drone | `drone @cli [command]` | Drone routes to `apps/cli.py:main()` |
+| Module | `python -m aipass.cli [args]` | `__main__.py` calls `main()` |
+| PATH | `aipass [args]` | `console_scripts` calls `cli_entry()` |
 
 ---
 

--- a/src/aipass/flow/README.md
+++ b/src/aipass/flow/README.md
@@ -2,8 +2,9 @@
 
 # Flow
 
-**Purpose:** Unified plan lifecycle management for AIPass. Creates, tracks, closes, and archives numbered work plans across multiple plan types via a filesystem-driven template registry. Foreground archival with vector intake verification, cross-branch aggregation, and self-healing registries.
+**Purpose:** Unified plan lifecycle management for AIPass. Creates, tracks, closes, and archives numbered work plans across multiple plan types via a filesystem-driven template registry.
 **Module:** `aipass.flow`
+**Version:** 2.2.1
 **Created:** 2025-11-15
 **Last Updated:** 2026-04-22
 
@@ -11,18 +12,21 @@
 
 ## Overview
 
-### What I Do
-- Create numbered plans from type-specific templates via `templates/` plugins
-- Unified create/close/list commands for all plan types (FPLAN, DPLAN, RPLAN, TDPLAN, ...)
-- Close plans with foreground archival to `.backup/processed_plans/`
-- Vector intake on close via `drone @memory process-plans` with chroma verification
-- List and filter plans across branches and plan types
-- Restore plans from backups
-- Template registry management: register, unregister, scan, auto-heal
-- Aggregate plans across branches
-- `--dry-run` for close preview
+Flow is AIPass's plan management system. Every branch uses flow to create, track, close, and archive work plans. Plans are numbered markdown files (`FPLAN-0042_subject_2026-04-22.md`) organized by type, with per-type registries tracking status and metadata.
 
-## Commands / Usage
+### What I Do
+- Create numbered plans from type-specific templates
+- Close plans with foreground archival and vector intake verification
+- List and filter plans across all registered types
+- Restore closed plans from backups
+- Manage plan types via filesystem-driven template registry
+- Aggregate plans across branches for central reporting
+- Self-heal registries (orphan detection, auto-close missing files, auto-register new template dirs)
+- Preview close operations with `--dry-run`
+
+---
+
+## Commands
 
 ```bash
 # Create plans
@@ -35,6 +39,7 @@ drone @flow close FPLAN-0042                    # Close specific plan
 drone @flow close DPLAN-0005                    # Close a DPLAN
 drone @flow close --all                         # Close all open plans
 drone @flow close --all --dry-run               # Preview what would close
+drone @flow close --dry-run FPLAN-0042          # Preview single close
 
 # List plans
 drone @flow list open                           # List open plans (all types)
@@ -46,10 +51,16 @@ drone @flow scan                                # Find unregistered directories
 drone @flow register <dir> <PREFIX>             # Register new plan type
 drone @flow unregister <dir>                    # Remove plan type
 
+# Registry
+drone @flow registry scan                       # Scan filesystem, detect mismatches
+drone @flow registry status                     # Show registry health
+
 # Other
 drone @flow restore FPLAN-0042                  # Reopen a closed plan
 drone @flow aggregate                           # Cross-branch plan aggregation
+drone @flow post                                # Background post-close processing
 drone @flow --help                              # Full help
+drone @flow --version                           # Version string
 ```
 
 ---
@@ -60,39 +71,46 @@ drone @flow --help                              # Full help
 flow/
 ├── apps/
 │   ├── flow.py                  # Entry point (auto-discovers modules)
-│   ├── modules/                 # Business logic (thin orchestrators)
+│   ├── modules/                 # Thin orchestrators (8 modules)
 │   │   ├── create_plan.py       # Plan creation with template support
 │   │   ├── close_plan.py        # Closure with foreground archival + vector verify
 │   │   ├── list_plans.py        # Plan listing and filtering
 │   │   ├── restore_plan.py      # Plan recovery from backups
-│   │   ├── registry_monitor.py  # Orphan detection, auto-healing
+│   │   ├── registry_monitor.py  # Registry scanning and auto-healing
 │   │   ├── aggregate_central.py # Cross-branch plan aggregation
-│   │   ├── post_close_runner.py # Background post-processing *(partial — archival moved to foreground)*
+│   │   ├── post_close_runner.py # Background post-processing with lock management
 │   │   └── template_manager.py  # Template registry management
 │   └── handlers/                # Implementation details
-│       ├── plan/                # Lifecycle, file ops, validation, close_ops
-│       ├── registry/            # Load, save, auto-heal
-│       ├── template/            # Plan type loader + template resolution + registry_ops
-│       ├── dashboard/           # Status aggregation
-│       ├── mbank/               # Memory archival
-│       └── json/                # Auto-creating JSON handler
-├── templates/                   # Plan type plugins (DATA, not code)
+│       ├── plan/                # Lifecycle: create, close, list, restore, display, validation
+│       ├── registry/            # Load, save, auto-heal registries
+│       ├── template/            # Plan type loader, template resolution, registry CRUD
+│       ├── dashboard/           # Status push to local, central, branch dashboards
+│       ├── mbank/               # Memory archival and plan processing
+│       ├── runner/              # Lock file operations for background processes
+│       ├── json/                # Auto-creating JSON handler
+│       ├── summary/             # Plan summarization (vestigial)
+│       ├── config/              # Configuration loading
+│       └── events/              # Event handling stubs
+├── templates/                   # Plan type plugins (data, not code)
 │   ├── flow_plans/              # FPLAN templates (default, master)
 │   ├── dev_plans/               # DPLAN templates (default)
 │   ├── research_plans/          # RPLAN templates (default)
 │   ├── team_dev_plans/          # TDPLAN templates (default)
-│   └── audit_plans/             # Unregistered — needs `drone @flow register`
+│   └── audit_plans/             # APLAN templates (default)
 ├── flow_json/                   # Per-type registries + template_registry.json
-├── tests/                       # 452 tests, 90/90 functions covered
-├── docs/                        # Documentation
+├── tests/                       # 423 tests, 17 test files
 └── .archive/                    # Archived legacy code
 ```
+
+### Design Principles
+- **Modules are thin orchestrators** — no business logic, route to handlers and display results
+- **Handlers are stateless** — modules inject dependencies (registry loader, paths, config)
+- **Plan types are filesystem-driven** — drop a template dir, register a prefix, done
+- **Auto-discovery** — `flow.py` finds modules via `handle_command()` convention; `plan_type_loader.py` discovers types from `template_registry.json`
 
 ---
 
 ## Plan Types
-
-Plan types are filesystem-driven. Drop a directory with `.md` templates into `templates/`, register it with a prefix. No per-directory JSON config needed.
 
 | Type | Prefix | Registry | Templates |
 |------|--------|----------|-----------|
@@ -100,52 +118,67 @@ Plan types are filesystem-driven. Drop a directory with `.md` templates into `te
 | dev_plans | DPLAN | dplan_registry.json | default |
 | research_plans | RPLAN | rplan_registry.json | default |
 | team_dev_plans | TDPLAN | tdplan_registry.json | default |
+| audit_plans | APLAN | aplan_registry.json | default |
 
-Plans follow the convention `{PREFIX}-{NNNN}_topic_slug_YYYY-MM-DD.md` where NNNN is auto-incrementing per type.
+Plans follow the naming convention `{PREFIX}-{NNNN}_topic_slug_YYYY-MM-DD.md` where NNNN auto-increments per type.
 
-### Auto-heal
-- Template registry auto-prunes orphaned types (directory deleted → entry + plan registry JSON removed on next command)
+### Adding a New Plan Type
+1. Create a directory in `templates/` with one or more `.md` template files
+2. Run `drone @flow register <dirname> <PREFIX>` (or let auto-registration detect it on next command)
+3. Use `drone @flow create . "Subject" <shorthand>` to create plans of the new type
+
+### Auto-healing
+- Template registry auto-prunes orphaned types (directory deleted → entry + plan registry JSON removed)
 - Plan registries auto-close entries for missing files
+- New template directories auto-register on next command
 
 ---
 
 ## Close Pipeline
 
 On `drone @flow close`:
-1. Template check (fast-delete empty templates)
-2. Mark as closed in registry
-3. Archive to `.backup/processed_plans/` (foreground, sets processed/cleanup flags atomically)
-4. Vector intake: `drone @memory process-plans` + `is_plan_vectorized()` verification
-5. Dashboard updates (local + central + branch)
-6. Append to `CLOSED_PLANS.local.json`
+1. **Template check** — fast-delete empty/template-only plans
+2. **Mark closed** — update plan registry with closure timestamp
+3. **Archive** — move to `.backup/processed_plans/` (foreground, sets processed/cleanup flags atomically)
+4. **Vector intake** — `drone @memory process-plans` + `is_plan_vectorized()` verification
+5. **Dashboard updates** — local, central, and branch dashboards
+6. **Append** — write to `CLOSED_PLANS.local.json`
+
+Vector verification displays in console: "Vectorized: N chunks in chroma" or "NOT vectorized".
 
 ---
 
 ## Integration Points
 
 ### Depends On
-- `aipass.cli` -- Terminal formatting (console, header, success, error)
-- `aipass.prax` -- Structured logging via `system_logger`
-- `aipass.trigger` -- Error reporting (optional)
-- `aipass.memory` -- Vector intake on plan close (`process-plans` + `verify`)
-- Python stdlib (`pathlib`, `json`, `importlib`, `sys`, `signal`, `subprocess`, `shutil`)
+- `aipass.cli` — Rich terminal formatting (`console`, `header`, `success`, `error`, `warning`)
+- `aipass.prax` — Structured logging via `system_logger`
+- `aipass.memory` — Vector intake on plan close
+- `aipass.trigger` — Error reporting (optional)
 
 ### Provides To
-- All branches -- Plan creation, tracking, closure, and archival
-- `aipass.devpulse` -- Plan status aggregation for system dashboards
-- Registry: Per-type registries in `flow_json/`
+- All branches — plan creation, tracking, closure, and archival
+- `aipass.devpulse` — plan status aggregation for system dashboards
+- Central reporting — `PLANS.central.json` via aggregate
 
 ---
 
 ## Quality
 
-- **Seedgo:** 100% (all 33 standards)
-- **Tests:** 452 tests, 90/90 public functions covered
-- **Last audit:** 2026-04-09
+- **Seedgo:** 100% (33/33 standards)
+- **Tests:** 423 passed, 83/87 public functions tested (95%)
+- **Source files:** 39 tracked by seedgo
+- **Last audit:** 2026-04-22
+- **Battle test:** 16/16 commands pass via drone CLI (2026-04-22)
+
+### Known Issues
+- Registry scan fires trigger events that are never handled (by design — foreground close handles everything)
+- Dashboard push warns on some closes
+- `mbank/process.py` at 669 lines (nearing 700 limit)
 
 ---
 
-*Last Updated: 2026-04-07*
+*Last Updated: 2026-04-22*
 
 ---
 [← Back to AIPass](../../../README.md)

--- a/src/aipass/seedgo/README.md
+++ b/src/aipass/seedgo/README.md
@@ -1,9 +1,10 @@
-[← Back to AIPass](../../../README.md)
+[<- Back to AIPass](../../../README.md)
 
 # Seedgo
 
-**Purpose:** Standards compliance platform for AIPass modules. Audits Python code against checker packs, scores each file, and reports violations. Ships with the `aipass_standards` pack (32 checkers covering imports, architecture, naming, logging, documentation, and more).
+**Purpose:** Standards compliance platform for AIPass. Audits all 11 core agents against 33 code standards + diagnostics, manages bypass rules, runs proof certification, owns the hook system, and provides per-file checklist validation consumed by auto-fix hooks.
 **Module:** `aipass.seedgo`
+**Version:** 2.0.0
 **Created:** 2026-03-05
 
 ---
@@ -11,47 +12,78 @@
 ## Overview
 
 ### What I Do
-- Audit Python modules against checker packs via auto-discovered modules
-- Score files and report violations with actionable details
-- Query standard content by pack and name
-- Support bypass rules for deliberate exceptions
+- Audit all 11 core agents against 33 code standards + diagnostics (architecture, CLI, imports, logging, naming, silent catch, deep nesting, etc.)
+- Score files 0-100 per standard and report violations with actionable details
+- Manage bypass rules (`.seedgo/bypass.json`) for deliberate exceptions
+- Run pyright diagnostics across branches for type error detection
+- Own the hook system: auto-fix diagnostics, edit gate, subagent stop gate, bridge installer
+- Single-file checklist validation against all standards (consumed by PostToolUse auto-fix hook)
+- Proof certification via proof/proof_query (triplet, plugin integrity, README currency)
+- Custom function test coverage mapping via test_map
+- README auto-generation and freshness checking
+- Hook testing, listing, and probe infrastructure
 
-## Commands / Usage
+### What I Don't Do
+- Runtime monitoring (that's prax)
+- Code execution or deployment
 
-Seedgo provides standards auditing, content queries, per-file checklists, diagnostics, and README generation.
+---
 
-### CLI
+## Commands
+
+### Via Drone (primary)
 
 ```bash
-seedgo --help                                          # Show usage
-seedgo --version                                       # Show version
+drone @seedgo                                          # Introspection (module list, version)
+drone @seedgo --help                                   # Full command listing
+drone @seedgo --version                                # Version string
 
 # Audit
-seedgo audit                                           # Show available checker packs
-seedgo audit aipass                                    # Audit all branches
-seedgo audit aipass flow                               # Audit single branch
+drone @seedgo audit aipass                             # Audit all 11 agents (33 standards + diagnostics)
+drone @seedgo audit aipass @flow                       # Audit single branch
+drone @seedgo audit inbox-ids                          # Inbox message-ID validation
 
-# Query Standards
-seedgo standards_query                                 # List available packs
-seedgo standards_query aipass_standards                 # List standards in pack
-seedgo standards_query aipass_standards architecture    # Show standard content
+# Standards Query
+drone @seedgo standards_query aipass_standards         # List all 33 standards in pack
+drone @seedgo standards_query aipass_standards cli     # Show specific standard content
+
+# Per-file Check
+drone @seedgo checklist <file>                         # Single-file standards check (hook consumer)
+drone @seedgo checklist <directory>                    # Directory-wide check (globs *.py)
+
+# Diagnostics
+drone @seedgo diagnostics                              # Pyright type checking via audit pipeline
+
+# Proof
+drone @seedgo proof aipass                             # Proof certification (CERTIFIED / NOT CERTIFIED)
+drone @seedgo proof_query aipass_proof triplet          # Query proof standard content
+
+# Test Coverage
+drone @seedgo test_map @seedgo                         # Function-level test coverage mapping
+
+# README
+drone @seedgo readme update @flow                      # README auto-generation for a branch
+
+# Hooks
+drone @seedgo hooks test                               # Run hook test suite (pytest per file)
+drone @seedgo hooks list                               # Show all wired hooks from settings
+drone @seedgo hooks probe                              # Hook event probe infrastructure
+
+# Bridge
+drone @seedgo bridge install                           # Install AIPass hooks to ~/.claude/settings.json
+drone @seedgo bridge uninstall                         # Remove AIPass hooks
+drone @seedgo bridge reinstall                         # Clean reinstall
+drone @seedgo bridge status                            # Show hook installation status
 ```
 
-### Via Drone
+### Via Python Module
 
 ```bash
-drone @seedgo                                          # Introspection
-drone @seedgo --help                                   # Full help
-drone @seedgo audit aipass                             # Audit all branches
-drone @seedgo audit aipass @spawn                      # Audit specific branch
-drone @seedgo standards_query aipass_standards cli      # Show standard content
-drone @seedgo checklist <file>                         # Per-file standards check
-drone @seedgo diagnostics                              # Pyright diagnostics
-drone @seedgo proof aipass                             # Proof certification
-drone @seedgo test_map @seedgo                         # Function test coverage
+python3 -m aipass.seedgo audit aipass                  # Same commands, direct execution
+python3 -m aipass.seedgo standards_query aipass_standards cli
 ```
 
-> **Note:** `proof`, `proof_query`, and `test_map` commands work but are not listed in `--help` output *(partial)*
+> **Note:** `proof`, `proof_query`, and `test_map` commands work but are not listed in `--help` output (known TODO).
 
 ---
 
@@ -60,105 +92,176 @@ drone @seedgo test_map @seedgo                         # Function test coverage
 ```
 seedgo/
 ├── apps/
-│   ├── seedgo.py                    # Entry point — module discovery + routing
-│   ├── modules/
-│   │   ├── standards_audit.py       # Pack-aware compliance audit
+│   ├── seedgo.py                    # Entry point — thin router (~290 lines)
+│   │                                #   discover_modules() loads apps/modules/*.py
+│   │                                #   route_command() dispatches to first handler returning True
+│   ├── modules/                     # 13 business logic modules
+│   │   ├── standards_audit.py       # Pack-aware compliance audit orchestrator
 │   │   ├── standards_query.py       # Pack-aware content query
-│   │   ├── diagnostics_audit.py     # Pyright diagnostics
-│   │   ├── checklist.py             # Per-file standards checklist (hook consumption)
-│   │   ├── seedgo_proof.py          # Proof orchestrator
+│   │   ├── diagnostics_audit.py     # Pyright diagnostics via audit pipeline
+│   │   ├── checklist.py             # Per-file/dir standards check (hook consumer)
+│   │   ├── seedgo_proof.py          # Proof certification orchestrator
 │   │   ├── proof_query.py           # Proof content query
-│   │   ├── hook_bridge.py            # Hook bridge installer (install/uninstall AIPass hooks)
+│   │   ├── hook_bridge.py           # Hook bridge installer (install/uninstall/reinstall/status)
 │   │   ├── hooks.py                 # Hook probe display and testing
 │   │   ├── hooks_ext.py             # Hook test + list subcommands (split from hooks.py)
-│   │   ├── inbox_audit.py           # Inbox message-ID validation (drone @seedgo audit inbox-ids)
-│   │   ├── permissions.py           # Shared trust list for hook + drone authorization
-│   │   ├── readme_update.py         # README generation
+│   │   ├── inbox_audit.py           # Inbox message-ID validation
+│   │   ├── permissions.py           # TRUSTED_CROSS_WRITERS list for hook + drone auth
+│   │   ├── readme_update.py         # README generation module
 │   │   └── test_map.py              # Custom function test coverage mapping
-│   └── handlers/
-│       ├── aipass_standards/        # Built-in checker pack (32 standards)
+│   └── handlers/                    # 11 handler directories
+│       ├── aipass_standards/        # 33 checker standards (67 files)
 │       │   ├── *_check.py           # Checker implementations (score 0-100)
 │       │   ├── *_content.py         # Queryable standard content
 │       │   └── *.md                 # Standard documentation
+│       ├── aipass_proof/            # 5 proof validators (11 files)
+│       │   ├── triplet.py           # .trinity/ completeness
+│       │   ├── interface.py         # AUDIT_SCOPE + function signatures
+│       │   ├── plugin_integrity.py  # No hardcoded standard names
+│       │   ├── content_naming.py    # Function naming conventions
+│       │   └── readme_currency.py   # README freshness
 │       ├── audit/                   # Audit implementation
-│       │   ├── branch_audit.py      # Per-branch scoring
-│       │   ├── discovery.py         # Branch discovery
-│       │   └── audit_display.py     # Result formatting
-│       ├── aipass_proof/             # Proof pack (README currency, etc.)
+│       │   ├── branch_audit.py      # Per-branch scoring engine
+│       │   ├── discovery.py         # Branch discovery (CWD-first registry)
+│       │   └── audit_display.py     # Rich result formatting
 │       ├── bypass/                  # Bypass system
 │       │   ├── bypass_handler.py    # .seedgo/bypass.json loader
 │       │   └── ignore_handler.py    # .seedgo/ignore patterns
 │       ├── config/                  # Configuration handlers
-│       ├── diagnostics/             # Pyright integration
+│       ├── diagnostics/             # Pyright integration + branch discovery
 │       ├── file/                    # File operations
-│       ├── hooks/                   # Hook test runner + bridge installer
-│       ├── json/                    # JSON tracking
+│       ├── hooks/                   # Hook test runner
+│       ├── json/                    # JSON tracking (json_handler)
+│       ├── readme/                  # README generator + branch resolution
 │       └── test_map/                # Function test coverage scanner
+├── tests/                           # 26 test files, 495 tests
 ├── drone_adapter.py                 # Drone routing bridge
-├── .trinity/                        # Memory files
-└── README.md
+├── .trinity/                        # Identity + memory
+├── .seedgo/                         # Self-bypass rules
+├── .ai_mail.local/                  # Mailbox
+├── CLAUDE.md                        # Branch startup instructions
+└── STATUS.local.md                  # Current state summary
 ```
 
-### Pack Discovery Convention
+### Key Patterns
 
-Checker packs live in `handlers/*_standards/` directories. A valid pack must contain at least one `*_check.py` file. The `standards_audit` module strips the `_standards` suffix for the pack name used in commands (e.g., `aipass_standards/` → `audit aipass`). The `standards_query` module uses the full directory name (e.g., `standards_query aipass_standards`).
+**Module auto-discovery:** `discover_modules()` in seedgo.py loads all `.py` files from `apps/modules/`. Each module's `handle_command(command, args)` is called in discovery order; first returning `True` wins.
+
+**Pack discovery:** Checker packs live in `handlers/*_standards/` directories. `standards_audit` strips the `_standards` suffix for command routing (`aipass_standards/` -> `audit aipass`). `standards_query` uses the full directory name (`standards_query aipass_standards`).
+
+**CWD-first registry:** `_find_registry()` walks CWD parents first (for external project support), falls back to `__file__` parents, uses `*_REGISTRY.json` glob (not hardcoded name).
+
+**Bypass system:** `.seedgo/bypass.json` per branch. Each entry has file, standard, optional lines, and required reason. Checkers call `is_bypassed()` per violation. Bypass is intentional documented deviation, not ignoring.
 
 ---
 
-## Checker Packs
+## The 33 Standards
 
-The `aipass_standards` pack checks: architecture, CLI, CLI flags, commented logger, dead code, debug print, deep nesting, documentation, encapsulation, error handling, handlers, hardcoded key, help text, imports, introspection, JSON structure, log handler, log level, log structure, log visibility, meta, modules, naming, permission flags, readme, shebang, silent catch, stderr routing, test quality, todo, trigger, and unused function.
+| Standard | Scope | What It Checks |
+|----------|-------|----------------|
+| architecture | entry_point | Module/handler separation, entry point structure |
+| cli | all_files | Rich console usage, no bare print() |
+| cli_flags | entry_point | --help, --version flag handling |
+| commented_logger | all_files | No commented-out logger/logging calls |
+| dead_code | branch_level | Unreachable functions and dead imports |
+| debug_print | all_files | No debug print/pprint statements |
+| deep_nesting | all_files | Max nesting depth 4 (AST-measured) |
+| documentation | all_files | Docstrings on public functions |
+| encapsulation | all_files | No cross-branch imports, proper isolation |
+| error_handling | all_files | Try/except patterns, error propagation |
+| handlers | entry_point | Handler directory structure |
+| hardcoded_key | all_files | No hardcoded API keys or secrets |
+| help_text | all_files | --help content quality |
+| imports | all_files | Import ordering and grouping |
+| introspection | entry_point | No-args introspection gate |
+| json_structure | all_files | json_handler import + log_operation calls |
+| log_handler | all_files | Prax logger usage (not stdlib logging) |
+| log_level | all_files | Correct log level usage |
+| log_structure | all_files | Structured log message format |
+| log_visibility | all_files | Log output in key operations |
+| meta | all_files | File header metadata block |
+| modules | all_files | Module structure and naming |
+| naming | all_files | snake_case, column-0 constants |
+| permission_flags | all_files | No dangerous permission overrides |
+| readme | branch_level | README.md exists and is current |
+| ruff | branch_level + per-file | Ruff linter compliance |
+| shebang | all_files | No shebang lines in library code |
+| silent_catch | all_files | No bare except/pass patterns |
+| stderr_routing | all_files | Proper stderr vs stdout usage |
+| test_quality | branch_level | JSON handler test coverage (51 items, 11 categories) |
+| todo | all_files | No unresolved TODO/FIXME/HACK comments |
+| trigger | all_files | Trigger integration patterns |
+| unused_function | branch_level | No unreferenced public functions |
 
-New packs go in `handlers/<name>_standards/` — add `*_check.py` files that implement scoring functions, and optionally `*_content.py` files that provide `get_<name>_standards()` for content queries.
+---
+
+## Hook Ownership
+
+Seedgo owns the AIPass hook system. Canonical runtime location: `AIPass/.claude/hooks/`.
+
+| Hook | Event | What It Does |
+|------|-------|--------------|
+| auto_fix_diagnostics.py v5.2.0 | PostToolUse (Edit/Write) | py_compile + ruff + pattern checks + `drone @seedgo checklist` + pyright. Saves state for edit gate |
+| pre_edit_gate.py v1.3.0 | PreToolUse (Edit/Write) | Blocks edits to other files while type errors exist. Cross-branch inbox write protection |
+| subagent_stop_gate.py v1.0 | SubagentStop | Runs checklist on modified .py files, blocks stop until clean |
+| branch_prompt_loader.py | UserPromptSubmit | Injects `.aipass/aipass_local_prompt.md` when CWD is in a branch |
+| identity_injector.py | UserPromptSubmit | Injects passport identity block |
+| email_notification.py | UserPromptSubmit | Inbox banner |
+| pre_compact.py | PreCompact | Memory archival prep |
+| notification_sound.py | Notification | Sound effect |
+| stop_sound.py | Stop | Sound effect |
+| tool_use_sound.py | PreToolUse | Sound effect |
+
+The `bridge` module (`drone @seedgo bridge install`) manages hook installation to `~/.claude/settings.json` using the AIPASS_HOOK_MANIFEST (13 entries across 7 events).
+
+---
+
+## Tests
+
+- **26 test files**, **495 tests**, all passing
+- **198 public functions**, 81 tested (41% coverage)
+- **0 type errors** (pyright)
+- Key test areas: standards audit, checklist, bypass, JSON handler, hooks (probe, track A/B/E, utility, bridge), proof, README, diagnostics
 
 ---
 
 ## Integration Points
 
 ### Depends On
-- `aipass.cli` — Rich-based display formatting (`console`, `header`)
+- `aipass.cli` — Rich console, header formatting
 - `aipass.prax` — Structured logging via `logger`
 - `aipass.drone` — Branch resolution via `normalize_branch_arg`
-- Python stdlib (`pathlib`, `sys`, `importlib`)
+- Python stdlib (`pathlib`, `ast`, `importlib`, `json`, `re`)
 
 ### Provides To
-- All modules — standards auditing via `seedgo audit <pack>`
-- All modules — content queries via `seedgo standards_query <pack> <standard>`
-- `aipass.drone` — routed via `drone @seedgo` (registered as internal module)
+- All branches — standards auditing via `drone @seedgo audit aipass [@branch]`
+- All branches — content queries via `drone @seedgo standards_query`
+- All branches — per-file checklist via hook (PostToolUse -> checklist)
+- `aipass.drone` — in-process routing via `drone_adapter.py`
 
 ---
 
-## Proof System
+## Known Issues / Tech Debt
 
-The `seedgo_proof` module orchestrates proof checks and `proof_query` provides content queries against the `aipass_proof/` handler pack. Proof checks verify triplet completeness (passport + local + observations), interface compliance, plugin integrity, content naming conventions, and README currency. Results are scored per-branch like standard audits.
-
----
-
-## Diagnostics
-
-The `diagnostics_audit` module runs pyright type checking across branches via handlers in the `diagnostics/` directory. Reports type errors, missing imports, and signature mismatches. Integrated into the audit pipeline as a separate diagnostic pass.
-
----
-
-## Bypass System
-
-The `bypass/` handler directory contains `bypass_handler.py` and `ignore_handler.py`. These manage `.seedgo/bypass.json` files per branch, allowing specific files, standards, or lines to be exempted from audit scoring. Each bypass requires a documented reason and is tracked in audit output.
+- `audit_display.py`: 16 hardcoded display blocks for specific standards (DPLAN-0047 tracks dynamic refactor)
+- Hook location drift: `~/.claude/hooks/` vs `AIPass/.claude/hooks/` (DPLAN-0131)
+- `proof`, `proof_query`, `test_map` not listed in `--help` output
+- `documentation_check.py` 5-line lookahead limitation for multi-line function signatures
+- `dead_code_check.py` doesn't recognize `iterdir()` as valid discovery pattern
+- Cross-branch file write detection recommended but not yet in standards (S73 finding)
+- Test coverage at 41% — 117 public functions untested
 
 ---
 
-## Checklist
+## Latest Audit (2026-04-22)
 
-The `checklist` module provides quick per-file or per-directory standards checks. Designed for consumption by auto-fix hooks and pre-commit validation, returning pass/fail results without full audit overhead.
-
----
-
-## Test Map
-
-The `test_map` module and `test_map/` handler directory provide custom function-level test coverage mapping. Scans public functions in source files and cross-references them against test files to identify untested functions and coverage gaps.
+- **Seedgo score:** 100% (33/33 + diagnostics) — all standards green
+- **Tests:** 495 passed, 0 failed, 0 skipped
+- **Type errors:** 0
 
 ---
 
 **Last Updated:** 2026-04-22
 
 ---
-[← Back to AIPass](../../../README.md)
+[<- Back to AIPass](../../../README.md)


### PR DESCRIPTION
## Summary
- Full README.md rewrite reflecting seedgo's current state
- 33 standards table with scope and description for each
- All 13 modules and 11 handler directories documented
- Complete command reference with drone syntax
- Hook ownership inventory (10 hooks across 7 events)
- Architecture patterns: module auto-discovery, pack discovery, CWD-first registry, bypass system
- Tests: 495 passing, known issues, integration points

## Context
Dispatch from @devpulse (6c57106a) — full README update task.

## Test plan
- [x] No code changes, documentation only
- [x] Verified all file counts, command syntax, and standard names against actual codebase