### PR TITLE
feat(system): fix: pip install hook shipping + README Need Help line — bootstrap falls back to wheel-bundled _hooks when AIPASS_HOME hooks dir missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ claude                                # Or: codex, gemini — your agent reads i
 
 That's it. Your agent has identity, memory, a mailbox, and knows what AIPass is. Say "hi" — it picks up where it left off. Come back tomorrow, it remembers.
 
+> **Need help?** [Ask in Discussions](https://github.com/AIOSAI/AIPass/discussions) or [file feedback](https://github.com/AIOSAI/AIPass/issues/new?template=feedback.yml) — both take 30 seconds.
+
 Your project automatically gets access to every AIPass service — dispatch work to specialists, create plans, run quality audits, send feedback to devpulse. Agents within your project can email each other. All through `drone @branch command`.
 
 ### Explore the full framework

--- a/src/aipass/cli/apps/handlers/init/bootstrap.py
+++ b/src/aipass/cli/apps/handlers/init/bootstrap.py
@@ -74,16 +74,23 @@ HOOK_EVENTS: dict[str, str] = {
 def _ship_hooks(aipass_home: str, target: Path) -> list[str]:
     """Copy enforcement + injector hooks from AIPass install to target project.
 
-    Copies each hook file from {aipass_home}/.claude/hooks/ to
-    {target}/.claude/hooks/. Skips audio hooks. Overwrites existing files
-    only if source content differs (idempotent re-sync).
+    Copies each hook file to {target}/.claude/hooks/. Looks for hooks in two
+    locations (first match wins):
+      1. {aipass_home}/.claude/hooks/  — dev install (git clone)
+      2. aipass/_hooks/                — pip install (wheel-bundled)
 
-    Returns list of files written.
+    Skips audio hooks. Overwrites existing files only if source content
+    differs (idempotent re-sync). Returns list of files written.
     """
     source_dir = Path(aipass_home) / ".claude" / "hooks"
     if not source_dir.is_dir():
-        logger.info("No hooks directory at %s — skipping hook shipping", source_dir)
-        return []
+        # Fallback: pip install bundles hooks at aipass/_hooks/ inside the package
+        package_hooks = Path(__file__).resolve().parents[4] / "_hooks"
+        if package_hooks.is_dir():
+            source_dir = package_hooks
+        else:
+            logger.info("No hooks directory at %s or %s — skipping", source_dir, package_hooks)
+            return []
 
     dest_dir = target / ".claude" / "hooks"
     dest_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- fix: pip install hook shipping + README Need Help line — bootstrap falls back to wheel-bundled _hooks when AIPASS_HOME hooks dir missing
- 1 commit(s) ahead of origin/main
