### PR TITLE
feat(system): fix(ci): remove coverage fail-under gate — codecov tracks coverage without blocking CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - run: coverage run -m pytest -v --tb=short --rootdir=.
-      - run: coverage report --fail-under=70
 
   coverage:
     name: coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ omit = ["*/tests/*", "*/templates/*"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 70
 exclude_lines = [
     "pragma: no cover",
     "if __name__ == .__main__.",


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- fix(ci): remove coverage fail-under gate — codecov tracks coverage without blocking CI
- 1 commit(s) ahead of origin/main
