### PR TITLE
feat(system): fix: ignore CVE-2026-3219 pip vulnerability in security scan — upstream pip issue, no fix available yet

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
       - run: pip install pip-audit
       - run: pip install -e .
       - name: Pip audit
-        run: pip-audit --skip-editable
+        run: pip-audit --skip-editable --ignore-vuln CVE-2026-3219
 
   codeql:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- fix: ignore CVE-2026-3219 pip vulnerability in security scan — upstream pip issue, no fix available yet
- 1 commit(s) ahead of origin/main
