### PR TITLE
feat(system): fix: Python 3.10 mock.patch — add detector import to monitor/__init__.py + fix chroma_client module split in symbolic tests

### DIFF
--- a/src/aipass/memory/apps/handlers/monitor/__init__.py
+++ b/src/aipass/memory/apps/handlers/monitor/__init__.py
@@ -1,2 +1,6 @@
 # Minimal __init__.py - handler independence pattern
 # No exports - handlers import directly when needed
+
+# Python 3.10 mock.patch compatibility — submodules must be importable as
+# attributes for mock._dot_lookup to resolve dotted paths.
+from . import detector  # noqa: F401

--- a/src/aipass/memory/tests/test_symbolic_extras.py
+++ b/src/aipass/memory/tests/test_symbolic_extras.py
@@ -1177,6 +1177,13 @@ class TestDeleteFragment:
         s = _import_storage()
         client = _mock_chroma_client()
 
+        # Re-import chroma_client so mock.patch and the code resolve to the
+        # same module object.  The autouse fixture deletes it from sys.modules;
+        # on Python 3.10 mock._dot_lookup finds a stale parent attribute.
+        import importlib
+
+        importlib.import_module("aipass.memory.apps.handlers.symbolic.chroma_client")
+
         with patch(
             "aipass.memory.apps.handlers.symbolic.chroma_client.get_client",
             return_value=client,
@@ -1192,6 +1199,10 @@ class TestDeleteFragment:
         s = _import_storage()
         client = _mock_chroma_client()
         client.get_or_create_collection.side_effect = RuntimeError("db locked")
+
+        import importlib
+
+        importlib.import_module("aipass.memory.apps.handlers.symbolic.chroma_client")
 
         with patch(
             "aipass.memory.apps.handlers.symbolic.chroma_client.get_client",


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- fix: Python 3.10 mock.patch — add detector import to monitor/__init__.py + fix chroma_client module split in symbolic tests
- 1 commit(s) ahead of origin/main
