### PR TITLE
feat(spawn): add git_branch to passport templates (DPLAN-0154)

### DIFF
--- a/src/aipass/cli/README.md
+++ b/src/aipass/cli/README.md
@@ -6,10 +6,12 @@
 **Module:** `aipass.cli`
 **Version:** 2.0.0
 **Seedgo:** 100% (34/34 standards)
-**Tests:** 171 passing (6 files, 5/5 modules covered)
-**Last Updated:** 2026-04-22
+**Tests:** 203 passing (6 files, 5/5 modules covered)
+**Last Updated:** 2026-04-26
 
 ## Usage
+
+Import display functions from `aipass.cli` and call them to produce consistent Rich-formatted terminal output across all branches.
 
 ### Display Functions
 
@@ -146,12 +148,12 @@ cli/
 │       ├── json/
 │       │   └── json_handler.py # JSON lifecycle (CRUD, validation, rotation)
 │       └── templates/          # Empty — placeholder from scaffold
-├── tests/                      # 171 tests across 6 files
-│   ├── test_bootstrap.py       # 60 tests — init/update/hooks/memo/mailbox
+├── tests/                      # 203 tests across 6 files
+│   ├── test_bootstrap.py       # 72 tests — init/update/hooks/memo/mailbox/scaffold
 │   ├── test_json_handler.py    # 35 tests — CRUD, validation, rotation
 │   ├── test_display.py         # 28 tests — all display functions + routing
+│   ├── test_init_project.py    # 34 tests — command routing, agent, update, output
 │   ├── test_templates.py       # 19 tests — operation templates + routing
-│   ├── test_init_project.py    # 14 tests — command routing, error handling
 │   └── test_integration.py     # 8 tests — main() flow, entry points
 ├── cli_json/                   # Auto-created JSON (config, data, log)
 ├── logs/                       # Branch-level logs
@@ -201,7 +203,7 @@ json_handler.ensure_module_jsons("cli")  # Create all 3 if missing
 
 ---
 
-*Last Updated: 2026-04-22*
+*Last Updated: 2026-04-26*
 
 ---
 [← Back to AIPass](../../../README.md)

--- a/src/aipass/seedgo/README.md
+++ b/src/aipass/seedgo/README.md
@@ -2,7 +2,7 @@
 
 # Seedgo
 
-**Purpose:** Standards compliance platform for AIPass. Audits all 11 core agents against 33 code standards + diagnostics, manages bypass rules, runs proof certification, owns the hook system, and provides per-file checklist validation consumed by auto-fix hooks.
+**Purpose:** Standards compliance platform for AIPass. Audits all 11 core agents against 34 code standards + diagnostics, manages bypass rules, runs proof certification, owns the hook system, and provides per-file checklist validation consumed by auto-fix hooks.
 **Module:** `aipass.seedgo`
 **Version:** 2.0.0
 **Created:** 2026-03-05
@@ -12,7 +12,7 @@
 ## Overview
 
 ### What I Do
-- Audit all 11 core agents against 33 code standards + diagnostics (architecture, CLI, imports, logging, naming, silent catch, deep nesting, etc.)
+- Audit all 11 core agents against 34 code standards + diagnostics (architecture, CLI, imports, logging, naming, silent catch, deep nesting, etc.)
 - Score files 0-100 per standard and report violations with actionable details
 - Manage bypass rules (`.seedgo/bypass.json`) for deliberate exceptions
 - Run pyright diagnostics across branches for type error detection
@@ -31,6 +31,8 @@
 
 ## Commands
 
+All commands available via `drone @seedgo <command>` or `python3 -m aipass.seedgo <command>`.
+
 ### Via Drone (primary)
 
 ```bash
@@ -39,7 +41,7 @@ drone @seedgo --help                                   # Full command listing
 drone @seedgo --version                                # Version string
 
 # Audit
-drone @seedgo audit aipass                             # Audit all 11 agents (33 standards + diagnostics)
+drone @seedgo audit aipass                             # Audit all 11 agents (34 standards + diagnostics)
 drone @seedgo audit aipass @flow                       # Audit single branch
 drone @seedgo audit inbox-ids                          # Inbox message-ID validation
 
@@ -110,7 +112,7 @@ seedgo/
 │   │   ├── readme_update.py         # README generation module
 │   │   └── test_map.py              # Custom function test coverage mapping
 │   └── handlers/                    # 11 handler directories
-│       ├── aipass_standards/        # 33 checker standards (67 files)
+│       ├── aipass_standards/        # 34 checker standards (67 files)
 │       │   ├── *_check.py           # Checker implementations (score 0-100)
 │       │   ├── *_content.py         # Queryable standard content
 │       │   └── *.md                 # Standard documentation
@@ -134,7 +136,7 @@ seedgo/
 │       ├── json/                    # JSON tracking (json_handler)
 │       ├── readme/                  # README generator + branch resolution
 │       └── test_map/                # Function test coverage scanner
-├── tests/                           # 26 test files, 495 tests
+├── tests/                           # 29 test files, 1131 tests
 ├── drone_adapter.py                 # Drone routing bridge
 ├── .trinity/                        # Identity + memory
 ├── .seedgo/                         # Self-bypass rules
@@ -155,7 +157,7 @@ seedgo/
 
 ---
 
-## The 33 Standards
+## The 34 Standards
 
 | Standard | Scope | What It Checks |
 |----------|-------|----------------|
@@ -169,6 +171,7 @@ seedgo/
 | documentation | all_files | Docstrings on public functions |
 | encapsulation | all_files | No cross-branch imports, proper isolation |
 | error_handling | all_files | Try/except patterns, error propagation |
+| handler_import | branch_level | apps/__init__.py contains `from . import handlers` |
 | handlers | entry_point | Handler directory structure |
 | hardcoded_key | all_files | No hardcoded API keys or secrets |
 | help_text | all_files | --help content quality |
@@ -218,10 +221,10 @@ The `bridge` module (`drone @seedgo bridge install`) manages hook installation t
 
 ## Tests
 
-- **26 test files**, **495 tests**, all passing
-- **198 public functions**, 81 tested (41% coverage)
+- **29 test files**, **1131 tests**, all passing
+- **200 public functions**, 200 tested (100% coverage)
 - **0 type errors** (pyright)
-- Key test areas: standards audit, checklist, bypass, JSON handler, hooks (probe, track A/B/E, utility, bridge), proof, README, diagnostics
+- Key test areas: standards audit, checklist, bypass, JSON handler, hooks (probe, track A/B/E, utility, bridge), proof, README, diagnostics, line coverage (plugin integrity, diagnostics, audit display, branch audit, architecture, checklist)
 
 ---
 
@@ -249,19 +252,20 @@ The `bridge` module (`drone @seedgo bridge install`) manages hook installation t
 - `documentation_check.py` 5-line lookahead limitation for multi-line function signatures
 - `dead_code_check.py` doesn't recognize `iterdir()` as valid discovery pattern
 - Cross-branch file write detection recommended but not yet in standards (S73 finding)
-- Test coverage at 41% — 117 public functions untested
+- Test coverage: 200/200 public functions (100%) but line coverage still has gaps in 6 handler files
 
 ---
 
-## Latest Audit (2026-04-22)
+## Latest Audit (2026-04-26)
 
-- **Seedgo score:** 100% (33/33 + diagnostics) — all standards green
-- **Tests:** 495 passed, 0 failed, 0 skipped
+- **Seedgo score:** 100% (34/34 + diagnostics) — all standards green
+- **Tests:** 1131 passed, 0 failed, 0 skipped
+- **Coverage:** 200 public functions, 200 tested (100%)
 - **Type errors:** 0
 
 ---
 
-**Last Updated:** 2026-04-22
+**Last Updated:** 2026-04-26
 
 ---
 [<- Back to AIPass](../../../README.md)

--- a/src/aipass/spawn/templates/birthright/.trinity/passport.json
+++ b/src/aipass/spawn/templates/birthright/.trinity/passport.json
@@ -14,7 +14,8 @@
     "alias": "",
     "path": "{{CWD}}",
     "module": "{{MODULE}}",
-    "created": "{{DATE}}"
+    "created": "{{DATE}}",
+    "git_branch": "work/{{branchname}}"
   },
   "identity": {
     "citizen_class": "birthright",

--- a/src/aipass/spawn/templates/builder/.spawn/.template_registry.json
+++ b/src/aipass/spawn/templates/builder/.spawn/.template_registry.json
@@ -98,7 +98,7 @@
     "f014": {
       "path": ".trinity/passport.json",
       "name": "passport.json",
-      "content_hash": "9b1d3a691272",
+      "content_hash": "3f5a0c2037d2",
       "has_branch_placeholder": false
     },
     "f016": {
@@ -155,7 +155,7 @@
       "content_hash": "a4cf0a8e3b4f",
       "has_branch_placeholder": false
     },
-    "f015": {
+    "f026": {
       "path": "apps/modules/__init__.py",
       "name": "__init__.py",
       "content_hash": "e3b0c44298fc",
@@ -263,7 +263,7 @@
       "content_hash": "28e9ae373563",
       "has_branch_placeholder": false
     },
-    "f026": {
+    "f015": {
       "path": "apps/plugins/__init__.py",
       "name": "__init__.py",
       "content_hash": "e3b0c44298fc",

--- a/src/aipass/spawn/templates/builder/.trinity/passport.json
+++ b/src/aipass/spawn/templates/builder/.trinity/passport.json
@@ -14,7 +14,8 @@
     "alias": "",
     "path": "{{CWD}}",
     "module": "{{MODULE}}",
-    "created": "{{DATE}}"
+    "created": "{{DATE}}",
+    "git_branch": "work/{{branchname}}"
   },
   "identity": {
     "citizen_class": "builder",


### PR DESCRIPTION
## Summary
- Added `git_branch: "work/{{branchname}}"` to both builder and birthright passport.json templates
- New agents now get `git_branch` set automatically at creation (e.g. `work/my_agent`)
- No placeholder changes needed — `{{branchname}}` (lowercase) already exists in `build_replacements_dict`
- Template registry regenerated

## Verification
- 278 tests pass
- Seedgo 100% (46/46 functions tested)
- Ruff clean
- Manual verify: spawned test agent shows `git_branch: work/test_gb`

## Test plan
- [x] `pytest src/aipass/spawn/tests/ -q` — 278 passed
- [x] `drone @seedgo audit aipass @spawn` — 100%
- [x] `ruff check + format` — clean
- [x] Manual spawn confirms `git_branch` in passport

🤖 Generated with [Claude Code](https://claude.com/claude-code)