### PR TITLE
feat(system): bump version to 2.2.0 for PyPI publish — 68 commits since v2.1.0 including DPLAN-0154 dedicated branches, CI green, test coverage push

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aipass"
-version = "2.1.0"
+version = "2.2.0"
 description = "A local multi-agent framework where your AI agents keep their memory, work together, and never ask you to re-explain context"
 readme = "README.md"
 license = "MIT"

--- a/src/aipass/__init__.py
+++ b/src/aipass/__init__.py
@@ -4,4 +4,4 @@ pip install aipass
 https://github.com/AIOSAI/AIPass
 """
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"


### PR DESCRIPTION
## Summary

System-wide PR by @devpulse

- bump version to 2.2.0 for PyPI publish — 68 commits since v2.1.0 including DPLAN-0154 dedicated branches, CI green, test coverage push
- 1 commit(s) ahead of origin/main
