### PR TITLE
fix(memory): remove rollover from startup chain + add embedding deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ trinity = [
 memory = [
     "numpy>=2.0",
     "chromadb>=1.0",
+    "sentence-transformers>=2.0",
 ]
 seedgo = []
 dev = [

--- a/src/aipass/trigger/README.md
+++ b/src/aipass/trigger/README.md
@@ -181,7 +181,6 @@ trigger/
 - `aipass.prax` — Logging via `system_logger`
 - `aipass.cli` — Console output and formatting
 - `aipass.ai_mail` — `deliver_email_to_branch()` for dispatch emails (lazy import, graceful fallback)
-- `aipass.memory` — `run_rollover()` check on startup (lazy import)
 
 ### Provides To
 - All branches — Event bus (`Trigger.fire`, `Trigger.on`, `Trigger.off`)

--- a/src/aipass/trigger/apps/handlers/events/startup.py
+++ b/src/aipass/trigger/apps/handlers/events/startup.py
@@ -364,23 +364,6 @@ def _run_error_catchup(fire_event: Optional[Callable[..., None]] = None) -> None
         return
 
 
-def _run_memory_check() -> None:
-    """Run memory rollover check if available.
-
-    Uses memory's public modules API to avoid cross-branch handler guard.
-    Silent failure - handlers cannot use logger or print.
-    """
-    try:
-        from aipass.memory.apps.modules.rollover import run_rollover
-
-        run_rollover()
-    except ImportError:
-        return  # Memory not available
-    except Exception as exc:
-        _log_warning(f"memory check failed: {exc}")
-        return
-
-
 def handle_startup(**kwargs: Any) -> None:
     """Run startup checks - replaces Prax logger's hardcoded calls.
 
@@ -390,6 +373,3 @@ def handle_startup(**kwargs: Any) -> None:
     # Error catch-up (scan for missed errors)
     fire_event = kwargs.get("fire_event")
     _run_error_catchup(fire_event)
-
-    # Memory rollover check
-    _run_memory_check()

--- a/src/aipass/trigger/tests/test_startup_handler.py
+++ b/src/aipass/trigger/tests/test_startup_handler.py
@@ -57,51 +57,26 @@ class TestHandleStartup:
         """Passes fire_event kwarg to _run_error_catchup."""
         mod = _import_startup()
         mod._run_error_catchup = MagicMock()
-        mod._run_memory_check = MagicMock()
 
         fire_event = MagicMock()
         mod.handle_startup(fire_event=fire_event)
 
         mod._run_error_catchup.assert_called_once_with(fire_event)  # type: ignore[union-attr]
 
-    def test_calls_memory_check(self) -> None:
-        """Invokes _run_memory_check on every startup."""
-        mod = _import_startup()
-        mod._run_error_catchup = MagicMock()
-        mod._run_memory_check = MagicMock()
-
-        mod.handle_startup()
-
-        mod._run_memory_check.assert_called_once()  # type: ignore[union-attr]
-
     def test_passes_none_when_no_fire_event(self) -> None:
         """Without fire_event kwarg, passes None to error catchup."""
         mod = _import_startup()
         mod._run_error_catchup = MagicMock()
-        mod._run_memory_check = MagicMock()
 
         mod.handle_startup()
 
         mod._run_error_catchup.assert_called_once_with(None)  # type: ignore[union-attr]
 
-    def test_calls_both_helpers_in_order(self) -> None:
-        """Error catchup runs before memory check."""
-        mod = _import_startup()
-        call_order: list[str] = []
-        mod._run_error_catchup = MagicMock(side_effect=lambda *a, **kw: call_order.append("catchup"))
-        mod._run_memory_check = MagicMock(side_effect=lambda *a, **kw: call_order.append("memory"))
-
-        mod.handle_startup(fire_event=MagicMock())
-
-        assert call_order == ["catchup", "memory"]
-
     def test_extra_kwargs_do_not_crash(self) -> None:
         """Arbitrary extra kwargs are silently ignored."""
         mod = _import_startup()
         mod._run_error_catchup = MagicMock()
-        mod._run_memory_check = MagicMock()
 
         mod.handle_startup(fire_event=MagicMock(), extra_arg="ignored", count=42)
 
         mod._run_error_catchup.assert_called_once()  # type: ignore[union-attr]
-        mod._run_memory_check.assert_called_once()  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary
- **Issue 1 (Embedding failure)**: Added `sentence-transformers>=2.0` to pyproject.toml `[memory]` extras. The embedding subprocess (`embed_subprocess.py`) requires sentence-transformers + torch, but only numpy and chromadb were listed. Torch comes as a transitive dependency of sentence-transformers.
- **Issue 2 (Rollover banner noise)**: Removed `_run_memory_check()` from trigger's startup handler. Rollover no longer fires on every drone command — it's now on-demand only (`drone @memory rollover`) or via the watcher daemon. This eliminates the "Memory - Rollover Execution" banner from every drone invocation.

## Files changed
- `pyproject.toml` — add sentence-transformers to memory extras
- `src/aipass/trigger/apps/handlers/events/startup.py` — remove _run_memory_check function + call
- `src/aipass/trigger/tests/test_startup_handler.py` — remove memory check test cases
- `src/aipass/trigger/README.md` — remove stale memory dependency note

## Test plan
- [x] `drone @memory --help` — no rollover banner
- [x] `drone @memory status` — no rollover banner
- [x] `drone @memory rollover run` — embedding works, devpulse.local rolled over successfully (3 rounds to clear backlog)
- [x] 895 tests pass (892 memory + 3 trigger startup)
- [x] torch 2.11.0 and sentence-transformers 5.4.1 installed and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)