### PR TITLE
fix(setup): ensurepip check (#495) + git identity (#500) + secrets protection (#496)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -133,6 +133,19 @@ if [ "$PY_OK" != "1" ]; then
     fi
 fi
 
+# --- Check ensurepip (Debian/Ubuntu split it into python3-venv apt package) ---
+if ! $PYTHON -c 'import ensurepip' &>/dev/null 2>&1; then
+    echo ""
+    echo "FAIL: ensurepip is unavailable for $PYTHON."
+    echo "  Without it, 'python3 -m venv' creates a broken venv (no pip, no activate)."
+    echo ""
+    echo "  Debian/Ubuntu:  sudo apt install python3-venv python3-pip"
+    echo "  Fedora/RHEL:    sudo dnf install python3-pip"
+    echo "  Arch:           (included in base python — file a bug if you hit this)"
+    echo ""
+    exit 1
+fi
+
 # --- Create venv ---
 if [ "$IS_WINDOWS" -eq 1 ] && [ -f ".venv/Scripts/python.exe" ]; then
     # Windows: skip venv recreation if python.exe exists (rm -rf unreliable due to file locking)

--- a/setup.sh
+++ b/setup.sh
@@ -253,6 +253,7 @@ if [ ! -d "$SECRETS_DIR" ]; then
     echo "Creating secrets directory at $SECRETS_DIR ..."
     mkdir -p "$SECRETS_DIR"
     chmod 700 "$HOME/.secrets"
+    chmod 700 "$SECRETS_DIR"
     echo "  ~/.secrets/aipass/ ... created"
 else
     echo "Secrets directory already exists — skipping"
@@ -569,6 +570,24 @@ msys = os.environ.get("MSYSTEM", "") + os.environ.get("OSTYPE", "")
 if "MSYS" in msys or "msys" in msys or "MINGW" in msys:
     env_block["PYTHONUTF8"] = "1"
 settings["env"] = env_block
+
+# Deny rules — hard-block tool access to secrets
+permissions = settings.get("permissions", {})
+deny = permissions.get("deny", [])
+secrets_deny = [
+    "Read(~/.secrets/**)",
+    "Read(/home/*/.secrets/**)",
+    "Bash(cat *~/.secrets*)",
+    "Bash(less *~/.secrets*)",
+    "Bash(head *~/.secrets*)",
+    "Bash(tail *~/.secrets*)",
+    "Bash(*~/.secrets*)",
+]
+for rule in secrets_deny:
+    if rule not in deny:
+        deny.append(rule)
+permissions["deny"] = deny
+settings["permissions"] = permissions
 
 settings_path.write_text(json.dumps(settings, indent=2) + "\n")
 print(f"  hooks -> {settings_path}")

--- a/setup.sh
+++ b/setup.sh
@@ -264,6 +264,34 @@ if [ ! -f "$SECRETS_DIR/.env" ] && [ -f ".env.example" ]; then
     echo "  Copied .env.example → ~/.secrets/aipass/.env (add your API keys there)"
 fi
 
+# --- Git identity (commits fail without user.email / user.name) ---
+GIT_EMAIL=$(git config --global user.email 2>/dev/null || true)
+GIT_NAME=$(git config --global user.name 2>/dev/null || true)
+if [ -z "$GIT_EMAIL" ] || [ -z "$GIT_NAME" ]; then
+    echo ""
+    echo "Git identity not configured — commits will fail without it."
+    DEFAULT_EMAIL="aipass.system@gmail.com"
+    DEFAULT_NAME="AIOSAI"
+    if [ -t 0 ]; then
+        # Interactive — prompt with defaults
+        read -r -p "  Git user.email [$DEFAULT_EMAIL]: " INPUT_EMAIL
+        read -r -p "  Git user.name  [$DEFAULT_NAME]: " INPUT_NAME
+        GIT_EMAIL="${INPUT_EMAIL:-$DEFAULT_EMAIL}"
+        GIT_NAME="${INPUT_NAME:-$DEFAULT_NAME}"
+    else
+        # Non-interactive — use defaults
+        GIT_EMAIL="$DEFAULT_EMAIL"
+        GIT_NAME="$DEFAULT_NAME"
+        echo "  Non-interactive mode — using defaults ($GIT_EMAIL / $GIT_NAME)"
+    fi
+    git config --global user.email "$GIT_EMAIL"
+    git config --global user.name "$GIT_NAME"
+    git config --global pull.rebase true
+    echo "  Git identity set: $GIT_NAME <$GIT_EMAIL>"
+else
+    echo "Git identity: $GIT_NAME <$GIT_EMAIL>"
+fi
+
 # --- Generate branch registry ---
 if [ ! -f "AIPASS_REGISTRY.json" ]; then
     echo "Generating AIPASS_REGISTRY.json ..."

--- a/src/aipass/memory/README.md
+++ b/src/aipass/memory/README.md
@@ -5,7 +5,7 @@
 **Purpose:** Central memory archive — vector search, rollover, and memory management for all AIPass branches.
 **Module:** `aipass.memory`
 **Created:** 2026-03-07
-**Last Updated:** 2026-04-22
+**Last Updated:** 2026-05-02
 **Citizen Class:** builder
 
 ---

--- a/src/aipass/memory/apps/handlers/vector/embedder.py
+++ b/src/aipass/memory/apps/handlers/vector/embedder.py
@@ -126,7 +126,7 @@ class EmbeddingService:
         )
 
         # Restore original order
-        ordered_embeddings = [None] * len(texts)
+        ordered_embeddings: List[Any] = [None] * len(texts)
         for original_idx, sorted_idx in enumerate(sorted_indices):
             ordered_embeddings[sorted_idx] = embeddings[original_idx]
 

--- a/src/aipass/prax/README.md
+++ b/src/aipass/prax/README.md
@@ -143,8 +143,7 @@ prax/
 │       └── watcher/                   # Background system watchers
 ├── prax_json/                         # Auto-created per-module config/data/log files
 ├── templates/                         # Dashboard template schema (DASHBOARD.template.json)
-├── tests/                             # 375 tests across 16 files
-└── tools/                             # Standalone utilities (inbox_watchdog.py, verify_branch.py)
+└── tests/                             # 911 tests across 16 files
 ```
 
 ### Design Pattern

--- a/src/aipass/spawn/README.md
+++ b/src/aipass/spawn/README.md
@@ -139,9 +139,7 @@ spawn/
 │           └── json_handler.py          # Standard JSON I/O, operation logging, 7 API functions
 ├── templates/
 │   ├── builder/                         # Full scaffold template (45 files, 24 dirs)
-│   ├── birthright/                      # Minimal template
-│   └── .archive/
-│       └── agent_mock_branch/           # Reference implementation
+│   └── birthright/                      # Minimal template
 ├── tests/                               # 13 test files, 253 tests
 ├── spawn_json/                          # JSON tracking directory
 ├── tools/                               # Branch verification utilities

--- a/src/aipass/spawn/templates/builder/.spawn/.template_registry.json
+++ b/src/aipass/spawn/templates/builder/.spawn/.template_registry.json
@@ -155,7 +155,7 @@
       "content_hash": "a4cf0a8e3b4f",
       "has_branch_placeholder": false
     },
-    "f015": {
+    "f026": {
       "path": "apps/modules/__init__.py",
       "name": "__init__.py",
       "content_hash": "e3b0c44298fc",
@@ -263,7 +263,7 @@
       "content_hash": "28e9ae373563",
       "has_branch_placeholder": false
     },
-    "f026": {
+    "f015": {
       "path": "apps/plugins/__init__.py",
       "name": "__init__.py",
       "content_hash": "e3b0c44298fc",

--- a/src/aipass/trigger/README.md
+++ b/src/aipass/trigger/README.md
@@ -5,7 +5,7 @@
 **Purpose:** Event bus and error dispatch for AIPass. Branches fire events, registered handlers react. Medic watches logs for errors, fingerprints them, gates dispatch through an 8-stage pipeline, and notifies the responsible branch.
 **Module:** `aipass.trigger`
 **Version:** 2.2.0
-**Last Updated:** 2026-04-22
+**Last Updated:** 2026-05-02
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- **#495**: Add ensurepip probe before venv creation. On stock Debian/Ubuntu without python3-venv, setup.sh now fails with an actionable error instead of silently producing a broken venv.
- **#500**: Add git identity configuration. Detects missing user.email/user.name, prompts interactively (or uses AIPass defaults in non-interactive mode). Sets pull.rebase=true.
- **#496**: Protect ~/.secrets/ — adds permissions.deny block to ~/.claude/settings.json (7 deny rules blocking Read and Bash access to ~/.secrets/). Also fixes chmod on inner aipass/ dir (was 775, now 700 like parent).

Closes #495, closes #500, closes #496.