### PR TITLE
Add HVTrust badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Give Feedback](https://img.shields.io/badge/Give-Feedback-brightgreen)](https://github.com/AIOSAI/AIPass/issues/new?template=feedback.yml)
 [![codecov](https://codecov.io/gh/AIOSAI/AIPass/graph/badge.svg)](https://codecov.io/gh/AIOSAI/AIPass)
 [![OSS Health](https://oss-health-monitor.vercel.app/api/badge/AIOSAI/AIPass)](https://github.com/volotat/OSS-Health-Monitor)
+[![HVTrust](https://hvtracker.net/badge/aipass.svg)](https://hvtracker.net/agents/aipass)
 
 <p align="center">
   <img src="assets/logo.png" alt="AIPass" width="400" />


### PR DESCRIPTION
Hi — thanks for submitting AIPass to [HVTracker](https://hvtracker.net)! 👋

AIPass is now listed at **https://hvtracker.net/agents/aipass** with a **trust score of 65/100 (Grade C)**, **verified package provenance**, and active maintenance.

This tiny PR adds the live HVTrust badge next to your existing health badges:

```markdown
[![HVTrust](https://hvtracker.net/badge/aipass.svg)](https://hvtracker.net/agents/aipass)
```

[![HVTrust](https://hvtracker.net/badge/aipass.svg)](https://hvtracker.net/agents/aipass)

**What it is:** an independent, third-party trust score computed from public signals (OSSF Scorecard, package provenance, signed commits, maintenance, adoption) using a [published, versioned methodology](https://hvtracker.net/methodology). The badge is a plain SVG served from HVTracker, so it always reflects your current score — nothing to maintain once merged.

Totally optional, of course — feel free to close this if you'd rather not include it. If a signal looks wrong, you can [submit a correction](https://github.com/YugantM/hvtracker/issues/new?title=%5BCorrection%5D%20AIPass) and we'll review it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)